### PR TITLE
Add ECS (Elastic Common Schema) log format support (Issue #3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "slog-viewer",
   "displayName": "Slog Viewer - JSON Log Formatter",
   "description": "Beautiful structured log viewer for debugging. Automatically formats JSON/logfmt logs with syntax highlighting, filtering, and search. Works with any language (Go slog, Node.js pino, Python structlog, etc.)",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "publisher": "hojabri",
   "icon": "icon.png",
   "repository": {

--- a/src/logFormatter.test.ts
+++ b/src/logFormatter.test.ts
@@ -45,6 +45,71 @@ describe('logFormatter', () => {
     });
   });
 
+  describe('parseJSONLog - ECS format', () => {
+    it('should parse ECS log with log.level field', () => {
+      const input = '{"@timestamp":"2024-01-01T12:00:00.000Z","log.level":"DEBUG","message":"Processing request"}';
+      const result = parseJSONLog(input);
+      expect(result).not.toBeNull();
+      expect(result?.level).toBe('DEBUG');
+      expect(result?.message).toBe('Processing request');
+      expect(result?.timestamp).toBe('2024-01-01T12:00:00.000Z');
+    });
+
+    it('should exclude log.level from otherFields', () => {
+      const input = '{"@timestamp":"2024-01-01T12:00:00.000Z","log.level":"INFO","message":"test"}';
+      const result = parseJSONLog(input);
+      expect(result).not.toBeNull();
+      expect(result?.otherFields['log.level']).toBeUndefined();
+    });
+
+    it('should parse ECS log with all common ECS fields', () => {
+      const input = JSON.stringify({
+        "@timestamp": "2024-01-01T12:00:00.000Z",
+        "log.level": "DEBUG",
+        "message": "Stopping beans in phase 2147483647",
+        "process.pid": 23633,
+        "process.thread.name": "SpringApplicationShutdownHook",
+        "log.logger": "org.springframework.context.support.DefaultLifecycleProcessor",
+        "ecs.version": "8.11"
+      });
+      const result = parseJSONLog(input);
+      expect(result).not.toBeNull();
+      expect(result?.timestamp).toBe('2024-01-01T12:00:00.000Z');
+      expect(result?.level).toBe('DEBUG');
+      expect(result?.message).toBe('Stopping beans in phase 2147483647');
+      expect(result?.otherFields['process.pid']).toBe(23633);
+      expect(result?.otherFields['process.thread.name']).toBe('SpringApplicationShutdownHook');
+      expect(result?.otherFields['log.logger']).toBe('org.springframework.context.support.DefaultLifecycleProcessor');
+      expect(result?.otherFields['ecs.version']).toBe('8.11');
+    });
+
+    it('should parse ECS log without message field', () => {
+      const input = JSON.stringify({
+        "log.level": "DEBUG",
+        "process.pid": 23633,
+        "process.thread.name": "SpringApplicationShutdownHook",
+        "log.logger": "org.springframework.context.support.DefaultLifecycleProcessor",
+        "ecs.version": "8.11"
+      });
+      const result = parseJSONLog(input);
+      expect(result).not.toBeNull();
+      expect(result?.level).toBe('DEBUG');
+      expect(result?.message).toBeUndefined();
+    });
+
+    it('should detect ECS JSON log with isJSONLog', () => {
+      const input = '{"log.level":"DEBUG","message":"test","@timestamp":"2024-01-01T12:00:00.000Z"}';
+      expect(isJSONLog(input)).toBe(true);
+    });
+
+    it('should prefer standard level field over log.level', () => {
+      const input = '{"level":"ERROR","log.level":"DEBUG","message":"test"}';
+      const result = parseJSONLog(input);
+      expect(result).not.toBeNull();
+      expect(result?.level).toBe('ERROR');
+    });
+  });
+
   describe('parseJSONLog - logfmt format', () => {
     it('should parse basic logfmt log', () => {
       const result = parseJSONLog('time=2024-01-01 level=info msg=hello');

--- a/src/logFormatter.ts
+++ b/src/logFormatter.ts
@@ -229,7 +229,7 @@ export function parseJSONLog(line: string): ParsedLog | null {
 
     // Extract common fields (check various common field names)
     const timestamp = obj.time || obj.timestamp || obj.ts || obj['@timestamp'] || obj.datetime;
-    let level = obj.level || obj.severity || obj.lvl || obj.loglevel;
+    let level = obj.level || obj.severity || obj.lvl || obj.loglevel || obj['log.level'];
     const message = obj.message || obj.msg || obj.text;
 
     // Normalize log level to standard values
@@ -267,6 +267,7 @@ export function parseJSONLog(line: string): ParsedLog | null {
         keyLower !== 'severity' &&
         keyLower !== 'lvl' &&
         keyLower !== 'loglevel' &&
+        keyLower !== 'log.level' &&
         keyLower !== 'message' &&
         keyLower !== 'msg' &&
         keyLower !== 'text'


### PR DESCRIPTION
Support log.level field used by ECS-formatted logs from Elastic Stack and Log4j ECS formatter. The log.level field is now recognized for level extraction and filtering.