### PR TITLE
Add VS Code Task support for structured log capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Beautiful structured log viewer for debugging. Automatically transforms JSON/log
 ## Features
 
 - **Automatic Detection**: Detects and formats JSON/logfmt logs during debugging
+- **Task Support**: Capture structured logs from VS Code Tasks (`"type": "slogViewer"`)
 - **Interactive UI**: Modern webview with VSCode theme integration
 - **Advanced Filtering**: Click any field to include/exclude logs by value
 - **Filtering & Search**: Filter by log level and search across messages
@@ -16,8 +17,63 @@ Beautiful structured log viewer for debugging. Automatically transforms JSON/log
 ## Quick Start
 
 1. Install the extension
-2. Start debugging (F5)
-3. View formatted logs in the **Slog Viewer** panel
+2. **Option A — Debugging**: Start debugging (F5) and view formatted logs in the **Slog Viewer** panel
+3. **Option B — Tasks**: Define a task with `"type": "slogViewer"` in `.vscode/tasks.json` and run it
+
+## Task Support
+
+VS Code Tasks let you run commands directly from VS Code. By using `"type": "slogViewer"` instead of `"type": "shell"`, the extension captures structured logs and displays them in the Slog Viewer panel — while still showing all raw output in the terminal.
+
+**Before** (standard shell task — logs only in terminal):
+```json
+{
+  "label": "Run Server",
+  "type": "shell",
+  "command": "node",
+  "args": ["server.js"]
+}
+```
+
+**After** (slogViewer task — logs in Slog Viewer panel + terminal):
+```json
+{
+  "label": "Run Server",
+  "type": "slogViewer",
+  "command": "node",
+  "args": ["server.js"]
+}
+```
+
+### Complete `tasks.json` Example
+
+```json
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Run Dev Server",
+      "type": "slogViewer",
+      "command": "node",
+      "args": ["${workspaceFolder}/server.js"],
+      "cwd": "${workspaceFolder}",
+      "env": {
+        "NODE_ENV": "development"
+      }
+    }
+  ]
+}
+```
+
+### Task Properties
+
+| Property  | Required | Description                          |
+|-----------|----------|--------------------------------------|
+| `command` | Yes      | The command to execute                |
+| `args`    | No       | Array of command arguments            |
+| `cwd`     | No       | Working directory (defaults to workspace folder) |
+| `env`     | No       | Additional environment variables      |
+
+Variable substitution is supported: `${workspaceFolder}`, `${file}`, `${env:VAR_NAME}`.
 
 ## Supported Formats
 
@@ -57,4 +113,3 @@ Access via VSCode Settings → "Slog Viewer":
 ## License
 
 MIT
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "slog-viewer",
-  "version": "1.1.1",
+  "version": "1.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "slog-viewer",
-      "version": "1.1.1",
+      "version": "1.1.4",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^30.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "slog-viewer",
   "displayName": "Slog Viewer - JSON Log Formatter",
   "description": "Beautiful structured log viewer for debugging. Automatically formats JSON/logfmt logs with syntax highlighting, filtering, and search. Works with any language (Go slog, Node.js pino, Python structlog, etc.)",
-  "version": "1.1.4",
+  "version": "1.2.0",
   "publisher": "hojabri",
   "icon": "icon.png",
   "repository": {
@@ -22,10 +22,12 @@
     "slog",
     "debug",
     "console",
-    "structured-logging"
+    "structured-logging",
+    "tasks"
   ],
   "activationEvents": [
-    "onDebug"
+    "onDebug",
+    "onTaskType:slogViewer"
   ],
   "main": "./dist/extension.js",
   "contributes": {
@@ -56,7 +58,36 @@
     "viewsWelcome": [
       {
         "view": "slog-viewer.logView",
-        "contents": "No logs yet.\n\nStart debugging to see formatted structured logs.\n\n[Start Debugging](command:workbench.action.debug.start)"
+        "contents": "No logs yet.\n\nStart debugging or run a slogViewer task to see formatted structured logs.\n\n[Start Debugging](command:workbench.action.debug.start)"
+      }
+    ],
+    "taskDefinitions": [
+      {
+        "type": "slogViewer",
+        "required": [
+          "command"
+        ],
+        "properties": {
+          "command": {
+            "type": "string",
+            "description": "The command to execute"
+          },
+          "args": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Command arguments"
+          },
+          "cwd": {
+            "type": "string",
+            "description": "Working directory"
+          },
+          "env": {
+            "type": "object",
+            "description": "Environment variables"
+          }
+        }
       }
     ],
     "configuration": {

--- a/src/__mocks__/vscode.ts
+++ b/src/__mocks__/vscode.ts
@@ -2,8 +2,56 @@ export interface WorkspaceConfiguration {
   get<T>(section: string, defaultValue?: T): T | undefined;
 }
 
+export class EventEmitter<T> {
+  private listeners: Array<(e: T) => void> = [];
+  event = (listener: (e: T) => void) => {
+    this.listeners.push(listener);
+    return { dispose: () => { this.listeners = this.listeners.filter(l => l !== listener); } };
+  };
+  fire(data: T): void {
+    for (const listener of this.listeners) {
+      listener(data);
+    }
+  }
+  dispose(): void {
+    this.listeners = [];
+  }
+}
+
 export const workspace = {
   getConfiguration: (): WorkspaceConfiguration => ({
     get: <T>(section: string, defaultValue?: T): T | undefined => defaultValue
-  })
+  }),
+  workspaceFolders: undefined as any
+};
+
+export const window = {
+  activeTextEditor: undefined as any
+};
+
+export const tasks = {
+  registerTaskProvider: (_type: string, _provider: any) => ({ dispose: () => {} })
+};
+
+export class CustomExecution {
+  constructor(public callback: () => Thenable<any>) {}
+}
+
+export class Task {
+  constructor(
+    public definition: any,
+    public scope: any,
+    public name: string,
+    public source: string,
+    public execution?: any
+  ) {}
+}
+
+export enum TaskScope {
+  Global = 1,
+  Workspace = 2
+}
+
+export const Uri = {
+  file: (path: string) => ({ fsPath: path, scheme: 'file' })
 };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { SlogDebugAdapterTrackerFactory } from './debugAdapterWrapper';
 import { SlogViewerWebviewProvider } from './webviewPanel';
+import { SlogViewerTaskProvider } from './taskOutputTracker';
 
 let webviewProvider: SlogViewerWebviewProvider;
 
@@ -28,6 +29,12 @@ export function activate(context: vscode.ExtensionContext) {
   const trackerFactory = new SlogDebugAdapterTrackerFactory(webviewProvider);
   context.subscriptions.push(
     vscode.debug.registerDebugAdapterTrackerFactory('*', trackerFactory)
+  );
+
+  // Register Task Provider for slogViewer tasks
+  const taskProvider = new SlogViewerTaskProvider(webviewProvider);
+  context.subscriptions.push(
+    vscode.tasks.registerTaskProvider(SlogViewerTaskProvider.taskType, taskProvider)
   );
 
   // Track debug session lifecycle

--- a/src/messageTypes.ts
+++ b/src/messageTypes.ts
@@ -5,11 +5,11 @@
 import { ParsedLog } from './logFormatter';
 
 /**
- * Session information for multi-session support
+ * Session information for multi-session support (debug sessions and task sessions)
  */
 export interface SessionInfo {
-  id: string;           // vscode.DebugSession.id
-  name: string;         // vscode.DebugSession.name (e.g., "Launch server.js")
+  id: string;           // Session identifier (debug session ID or task-generated ID)
+  name: string;         // Display name (e.g., "Launch server.js" or "Task: Run Server")
   isActive: boolean;    // Whether session is still running
 }
 

--- a/src/taskOutputTracker.test.ts
+++ b/src/taskOutputTracker.test.ts
@@ -1,0 +1,222 @@
+import { resolveVariables, processChunk, normalizeLineEndings } from './taskOutputTracker';
+
+// Mock vscode module
+jest.mock('vscode');
+
+describe('taskOutputTracker', () => {
+  describe('processChunk', () => {
+    it('should process complete lines and buffer incomplete ones', () => {
+      const lines: string[] = [];
+      const remaining = processChunk('line1\nline2\npartial', '', (line) => lines.push(line));
+
+      expect(lines).toEqual(['line1', 'line2']);
+      expect(remaining).toBe('partial');
+    });
+
+    it('should handle empty buffer with complete lines', () => {
+      const lines: string[] = [];
+      const remaining = processChunk('hello\nworld\n', '', (line) => lines.push(line));
+
+      expect(lines).toEqual(['hello', 'world']);
+      expect(remaining).toBe('');
+    });
+
+    it('should combine buffered data with new chunk', () => {
+      const lines: string[] = [];
+      const remaining = processChunk('orld\nnext\n', 'hello w', (line) => lines.push(line));
+
+      expect(lines).toEqual(['hello world', 'next']);
+      expect(remaining).toBe('');
+    });
+
+    it('should handle single line without newline', () => {
+      const lines: string[] = [];
+      const remaining = processChunk('partial', '', (line) => lines.push(line));
+
+      expect(lines).toEqual([]);
+      expect(remaining).toBe('partial');
+    });
+
+    it('should skip empty lines', () => {
+      const lines: string[] = [];
+      const remaining = processChunk('line1\n\n\nline2\n', '', (line) => lines.push(line));
+
+      expect(lines).toEqual(['line1', 'line2']);
+      expect(remaining).toBe('');
+    });
+
+    it('should strip trailing carriage return from Windows line endings', () => {
+      const lines: string[] = [];
+      const remaining = processChunk('line1\r\nline2\r\n', '', (line) => lines.push(line));
+
+      expect(lines).toEqual(['line1', 'line2']);
+      expect(remaining).toBe('');
+    });
+
+    it('should handle multiple chunks building up a line', () => {
+      const lines: string[] = [];
+      let buffer = '';
+
+      buffer = processChunk('hel', buffer, (line) => lines.push(line));
+      expect(lines).toEqual([]);
+      expect(buffer).toBe('hel');
+
+      buffer = processChunk('lo wo', buffer, (line) => lines.push(line));
+      expect(lines).toEqual([]);
+      expect(buffer).toBe('hello wo');
+
+      buffer = processChunk('rld\n', buffer, (line) => lines.push(line));
+      expect(lines).toEqual(['hello world']);
+      expect(buffer).toBe('');
+    });
+  });
+
+  describe('normalizeLineEndings', () => {
+    it('should convert LF to CRLF', () => {
+      expect(normalizeLineEndings('line1\nline2\n')).toBe('line1\r\nline2\r\n');
+    });
+
+    it('should keep existing CRLF as CRLF (not double)', () => {
+      expect(normalizeLineEndings('line1\r\nline2\r\n')).toBe('line1\r\nline2\r\n');
+    });
+
+    it('should convert bare CR to CRLF', () => {
+      expect(normalizeLineEndings('line1\rline2\r')).toBe('line1\r\nline2\r\n');
+    });
+
+    it('should handle mixed line endings', () => {
+      expect(normalizeLineEndings('a\nb\r\nc\rd')).toBe('a\r\nb\r\nc\r\nd');
+    });
+
+    it('should handle empty string', () => {
+      expect(normalizeLineEndings('')).toBe('');
+    });
+
+    it('should handle string with no line endings', () => {
+      expect(normalizeLineEndings('no newlines here')).toBe('no newlines here');
+    });
+  });
+
+  describe('resolveVariables', () => {
+    it('should resolve ${workspaceFolder}', () => {
+      const folder = {
+        uri: { fsPath: '/home/user/project' },
+        name: 'project',
+        index: 0
+      } as any;
+
+      expect(resolveVariables('${workspaceFolder}/src/app.js', folder)).toBe('/home/user/project/src/app.js');
+    });
+
+    it('should resolve ${workspaceRoot} (legacy alias)', () => {
+      const folder = {
+        uri: { fsPath: '/home/user/project' },
+        name: 'project',
+        index: 0
+      } as any;
+
+      expect(resolveVariables('${workspaceRoot}/src', folder)).toBe('/home/user/project/src');
+    });
+
+    it('should resolve ${env:VAR_NAME}', () => {
+      const original = process.env.TEST_SLOG_VAR;
+      process.env.TEST_SLOG_VAR = 'hello123';
+
+      expect(resolveVariables('prefix-${env:TEST_SLOG_VAR}-suffix')).toBe('prefix-hello123-suffix');
+
+      if (original === undefined) {
+        delete process.env.TEST_SLOG_VAR;
+      } else {
+        process.env.TEST_SLOG_VAR = original;
+      }
+    });
+
+    it('should resolve missing env var to empty string', () => {
+      delete process.env.__NONEXISTENT_SLOG_TEST_VAR__;
+      expect(resolveVariables('${env:__NONEXISTENT_SLOG_TEST_VAR__}')).toBe('');
+    });
+
+    it('should resolve multiple variables in one string', () => {
+      const folder = {
+        uri: { fsPath: '/workspace' },
+        name: 'ws',
+        index: 0
+      } as any;
+
+      process.env.TEST_SLOG_PORT = '3000';
+      const result = resolveVariables('${workspaceFolder}/run --port ${env:TEST_SLOG_PORT}', folder);
+      expect(result).toBe('/workspace/run --port 3000');
+      delete process.env.TEST_SLOG_PORT;
+    });
+
+    it('should return string unchanged when no variables present', () => {
+      expect(resolveVariables('node server.js')).toBe('node server.js');
+    });
+
+    it('should handle no folder gracefully for workspaceFolder', () => {
+      expect(resolveVariables('${workspaceFolder}/src')).toBe('${workspaceFolder}/src');
+    });
+  });
+
+  describe('SlogViewerTaskProvider.resolveTask', () => {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { SlogViewerTaskProvider } = require('./taskOutputTracker');
+
+    it('should return undefined for missing command', () => {
+      const mockWebview = {} as any;
+      const provider = new SlogViewerTaskProvider(mockWebview);
+
+      const task = {
+        definition: { type: 'slogViewer' },
+        name: 'test',
+        scope: undefined,
+        source: 'slogViewer'
+      } as any;
+
+      const result = provider.resolveTask(task);
+      expect(result).toBeUndefined();
+    });
+
+    it('should return undefined for wrong task type', () => {
+      const mockWebview = {} as any;
+      const provider = new SlogViewerTaskProvider(mockWebview);
+
+      const task = {
+        definition: { type: 'shell', command: 'echo hello' },
+        name: 'test',
+        scope: undefined,
+        source: 'shell'
+      } as any;
+
+      const result = provider.resolveTask(task);
+      expect(result).toBeUndefined();
+    });
+
+    it('should return a Task for valid definition', () => {
+      const mockWebview = {
+        addTaskSession: jest.fn(),
+        show: jest.fn(),
+        addLog: jest.fn(),
+        endSession: jest.fn()
+      } as any;
+      const provider = new SlogViewerTaskProvider(mockWebview);
+
+      const task = {
+        definition: { type: 'slogViewer', command: 'node app.js' },
+        name: 'Run App',
+        scope: undefined,
+        source: 'slogViewer'
+      } as any;
+
+      const result = provider.resolveTask(task);
+      expect(result).toBeDefined();
+      expect(result.name).toBe('Run App');
+    });
+
+    it('should provide empty array from provideTasks', () => {
+      const mockWebview = {} as any;
+      const provider = new SlogViewerTaskProvider(mockWebview);
+      expect(provider.provideTasks()).toEqual([]);
+    });
+  });
+});

--- a/src/taskOutputTracker.ts
+++ b/src/taskOutputTracker.ts
@@ -1,0 +1,305 @@
+import * as vscode from 'vscode';
+import * as cp from 'child_process';
+import { isJSONLog, parseJSONLog } from './logFormatter';
+import { SlogViewerWebviewProvider } from './webviewPanel';
+
+// Maximum number of recent lines to track for deduplication
+const MAX_PROCESSED_LINES = 1000;
+
+/**
+ * Resolve VS Code variables in a string value.
+ * VS Code does NOT perform variable substitution on custom task definition properties,
+ * so we must do it manually.
+ */
+export function resolveVariables(value: string, folder?: vscode.WorkspaceFolder): string {
+  let result = value;
+
+  // ${workspaceFolder} and ${workspaceRoot} (legacy alias)
+  if (folder) {
+    result = result.replace(/\$\{workspaceFolder\}/g, folder.uri.fsPath);
+    result = result.replace(/\$\{workspaceRoot\}/g, folder.uri.fsPath);
+  }
+
+  // ${file} — the currently active file
+  const activeEditor = vscode.window.activeTextEditor;
+  if (activeEditor) {
+    result = result.replace(/\$\{file\}/g, activeEditor.document.uri.fsPath);
+  }
+
+  // ${env:VAR_NAME}
+  result = result.replace(/\$\{env:([^}]+)\}/g, (_match, varName) => {
+    return process.env[varName] ?? '';
+  });
+
+  return result;
+}
+
+/**
+ * Process a data chunk with line buffering, calling onLine for each complete line.
+ * Returns the remaining incomplete line (to be buffered for the next chunk).
+ */
+export function processChunk(
+  data: string,
+  lineBuffer: string,
+  onLine: (line: string) => void
+): string {
+  const combined = lineBuffer + data;
+  const lines = combined.split('\n');
+
+  // The last element is either an incomplete line or empty string
+  const remaining = lines.pop() ?? '';
+
+  for (const line of lines) {
+    // Strip trailing \r for Windows-style line endings
+    const cleaned = line.replace(/\r$/, '');
+    if (cleaned.trim()) {
+      onLine(cleaned);
+    }
+  }
+
+  return remaining;
+}
+
+/**
+ * Normalize line endings for terminal display: convert all line endings to \r\n
+ */
+export function normalizeLineEndings(data: string): string {
+  return data.replace(/\r\n|\r|\n/g, '\r\n');
+}
+
+/**
+ * Pseudoterminal that spawns a process and intercepts structured log output.
+ */
+class SlogViewerPseudoterminal implements vscode.Pseudoterminal {
+  private writeEmitter = new vscode.EventEmitter<string>();
+  private closeEmitter = new vscode.EventEmitter<number | void>();
+
+  onDidWrite: vscode.Event<string> = this.writeEmitter.event;
+  onDidClose: vscode.Event<number | void> = this.closeEmitter.event;
+
+  private process: cp.ChildProcess | undefined;
+  private lineBuffer = '';
+  private errLineBuffer = '';
+  private processedLines: Set<string> = new Set();
+  private processedLinesQueue: string[] = [];
+  private hasShownWebview = false;
+
+  constructor(
+    private command: string,
+    private args: string[],
+    private cwd: string | undefined,
+    private env: Record<string, string> | undefined,
+    private sessionId: string,
+    private webviewProvider: SlogViewerWebviewProvider
+  ) {}
+
+  open(): void {
+    // Build the full command string
+    const fullCommand = this.args.length > 0
+      ? `${this.command} ${this.args.join(' ')}`
+      : this.command;
+
+    this.writeEmitter.fire(`\x1b[90m> ${fullCommand}\x1b[0m\r\n\r\n`);
+
+    const spawnEnv = this.env
+      ? { ...process.env, ...this.env }
+      : process.env;
+
+    const isWindows = process.platform === 'win32';
+
+    this.process = cp.spawn(fullCommand, [], {
+      shell: true,
+      cwd: this.cwd,
+      env: spawnEnv,
+      detached: !isWindows, // Process group for clean tree-killing on Unix
+    });
+
+    this.process.stdout?.on('data', (data: Buffer) => {
+      const str = data.toString();
+      // Write raw output to terminal (normalized line endings)
+      this.writeEmitter.fire(normalizeLineEndings(str));
+      // Process for structured logs
+      this.lineBuffer = processChunk(str, this.lineBuffer, (line) => {
+        this.processLine(line);
+      });
+    });
+
+    this.process.stderr?.on('data', (data: Buffer) => {
+      const str = data.toString();
+      // Write raw output to terminal (normalized line endings)
+      this.writeEmitter.fire(normalizeLineEndings(str));
+      // Process for structured logs
+      this.errLineBuffer = processChunk(str, this.errLineBuffer, (line) => {
+        this.processLine(line);
+      });
+    });
+
+    this.process.on('error', (err) => {
+      this.writeEmitter.fire(`\r\n\x1b[31mFailed to start process: ${err.message}\x1b[0m\r\n`);
+      this.closeEmitter.fire(1);
+    });
+
+    this.process.on('exit', (code) => {
+      // Flush remaining buffers
+      if (this.lineBuffer.trim()) {
+        this.processLine(this.lineBuffer);
+        this.lineBuffer = '';
+      }
+      if (this.errLineBuffer.trim()) {
+        this.processLine(this.errLineBuffer);
+        this.errLineBuffer = '';
+      }
+
+      this.writeEmitter.fire(`\r\n\x1b[90mProcess exited with code ${code ?? 'unknown'}\x1b[0m\r\n`);
+      this.webviewProvider.endSession(this.sessionId);
+      this.closeEmitter.fire(code ?? 0);
+    });
+  }
+
+  handleInput(data: string): void {
+    // Ctrl+C
+    if (data === '\x03') {
+      this.killProcess();
+      return;
+    }
+    // Forward other input to the process
+    this.process?.stdin?.write(data);
+  }
+
+  close(): void {
+    this.killProcess();
+  }
+
+  private killProcess(): void {
+    if (!this.process || this.process.exitCode !== null) {
+      return;
+    }
+
+    const pid = this.process.pid;
+    if (!pid) {
+      return;
+    }
+
+    try {
+      if (process.platform === 'win32') {
+        // Windows: kill the process tree
+        cp.exec(`taskkill /pid ${pid} /T /F`);
+      } else {
+        // macOS/Linux: kill the process group (negative PID)
+        process.kill(-pid, 'SIGTERM');
+      }
+    } catch {
+      // Process may have already exited
+      try {
+        this.process.kill('SIGTERM');
+      } catch {
+        // ignore
+      }
+    }
+  }
+
+  private processLine(line: string): void {
+    // Deduplication
+    if (this.processedLines.has(line)) {
+      return;
+    }
+
+    this.processedLines.add(line);
+    this.processedLinesQueue.push(line);
+
+    // Evict oldest entries if we exceed the limit
+    while (this.processedLinesQueue.length > MAX_PROCESSED_LINES) {
+      const oldest = this.processedLinesQueue.shift();
+      if (oldest) {
+        this.processedLines.delete(oldest);
+      }
+    }
+
+    if (isJSONLog(line)) {
+      const parsed = parseJSONLog(line);
+      if (parsed) {
+        this.webviewProvider.addLog(this.sessionId, parsed);
+
+        // Auto-show the webview on first structured log
+        if (!this.hasShownWebview) {
+          this.webviewProvider.show();
+          this.hasShownWebview = true;
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Task provider for the "slogViewer" task type.
+ * Users define tasks with "type": "slogViewer" in tasks.json and the extension
+ * spawns the process, piping output to both the terminal and the slog-viewer panel.
+ */
+export class SlogViewerTaskProvider implements vscode.TaskProvider {
+  static readonly taskType = 'slogViewer';
+
+  constructor(private webviewProvider: SlogViewerWebviewProvider) {}
+
+  provideTasks(): vscode.Task[] {
+    // Users define tasks in tasks.json; we don't provide any default tasks
+    return [];
+  }
+
+  resolveTask(task: vscode.Task): vscode.Task | undefined {
+    const definition = task.definition;
+
+    if (definition.type !== SlogViewerTaskProvider.taskType) {
+      return undefined;
+    }
+
+    const command: string | undefined = definition.command;
+    if (!command) {
+      return undefined;
+    }
+
+    const args: string[] = definition.args || [];
+    const cwd: string | undefined = definition.cwd;
+    const env: Record<string, string> | undefined = definition.env;
+
+    // Determine the workspace folder for variable resolution
+    const folder = task.scope !== undefined && task.scope !== vscode.TaskScope.Global && task.scope !== vscode.TaskScope.Workspace
+      ? task.scope as vscode.WorkspaceFolder
+      : vscode.workspace.workspaceFolders?.[0];
+
+    // Resolve variables in command, args, and cwd
+    const resolvedCommand = resolveVariables(command, folder);
+    const resolvedArgs = args.map((a: string) => resolveVariables(a, folder));
+    const resolvedCwd = cwd ? resolveVariables(cwd, folder) : folder?.uri.fsPath;
+
+    const webviewProvider = this.webviewProvider;
+    const sessionId = `task-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
+    const sessionName = `Task: ${task.name}`;
+
+    const execution = new vscode.CustomExecution(async () => {
+      // Create the task session in the webview
+      webviewProvider.addTaskSession(sessionId, sessionName);
+      webviewProvider.show();
+
+      return new SlogViewerPseudoterminal(
+        resolvedCommand,
+        resolvedArgs,
+        resolvedCwd,
+        env,
+        sessionId,
+        webviewProvider
+      );
+    });
+
+    // IMPORTANT: Must reuse the original task.definition object, not a copy,
+    // otherwise VS Code silently ignores the resolved task.
+    const resolvedTask = new vscode.Task(
+      definition,
+      task.scope ?? vscode.TaskScope.Workspace,
+      task.name,
+      task.source ?? SlogViewerTaskProvider.taskType,
+      execution
+    );
+
+    return resolvedTask;
+  }
+}

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -106,7 +106,7 @@
             <div class="empty-state">
                 <div class="empty-icon">📋</div>
                 <p>No logs yet</p>
-                <small>Start debugging to see formatted logs</small>
+                <small>Start debugging or run a slogViewer task to see formatted logs</small>
             </div>
         </div>
     </div>

--- a/src/webview/webview.js
+++ b/src/webview/webview.js
@@ -333,7 +333,7 @@ function renderCurrentSessionLogs() {
             <div class="empty-state">
                 <div class="empty-icon">📋</div>
                 <p>No logs yet</p>
-                <small>Start debugging to see formatted logs</small>
+                <small>Start debugging or run a slogViewer task to see formatted logs</small>
             </div>
         `;
         return;
@@ -844,7 +844,7 @@ function rerenderAllLogs() {
             <div class="empty-state">
                 <div class="empty-icon">📋</div>
                 <p>No logs yet</p>
-                <small>Start debugging to see formatted logs</small>
+                <small>Start debugging or run a slogViewer task to see formatted logs</small>
             </div>
         `;
         return;

--- a/src/webviewPanel.ts
+++ b/src/webviewPanel.ts
@@ -163,6 +163,16 @@ export class SlogViewerWebviewProvider implements vscode.WebviewViewProvider {
   }
 
   /**
+   * Add a new task session (not tied to a debug session)
+   */
+  public addTaskSession(id: string, name: string): void {
+    const sessionData: SessionData = { id, name, isActive: true, logs: [] };
+    this.sessions.set(id, sessionData);
+    this.currentSessionId = id;
+    this.sendSessionsToWebview();
+  }
+
+  /**
    * Mark a session as ended (keep logs for viewing)
    */
   public endSession(sessionId: string): void {


### PR DESCRIPTION
## Summary

- Register a custom `slogViewer` task type so users can capture structured logs from VS Code Tasks (not just debug sessions)
- Users change `"type": "shell"` to `"type": "slogViewer"` in `tasks.json` — everything else stays the same
- Uses stable `TaskProvider` + `CustomExecution` + `Pseudoterminal` APIs (works in published Marketplace extensions)
- Raw output still appears in the terminal; structured logs additionally appear in the Slog Viewer panel
- Supports variable substitution (`${workspaceFolder}`, `${file}`, `${env:VAR}`) in command, args, and cwd
- Bump version to 1.2.0

Closes #6

## Test plan

- [ ] Run `npm run compile` — builds without errors
- [ ] Run `npm test` — all 43 tests pass (21 existing + 22 new)
- [ ] Run `npm run lint` — no new lint errors
- [ ] Manual test: open `slog-viewer-demo/` in Extension Development Host, run "Run Demo Logger" task, verify structured logs appear in Slog Viewer panel
- [ ] Manual test: plain text lines do NOT appear in Slog Viewer
- [ ] Manual test: Ctrl+C stops the process and marks session as ended
- [ ] Manual test: running the task again creates a new session
- [ ] Regression: debug sessions still capture logs as before