### PR TITLE
Add log file viewer with live tail support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,41 @@
 
 All notable changes to the "Slog Viewer" extension will be documented in this file.
 
+## [1.3.0] - 2026-03-09
+
+### Added
+- **Open Log Files**: View any structured log file (JSON/logfmt) directly in the Slog Viewer panel
+- **Live Tail (Watch Mode)**: Monitor log files in real time with automatic detection of new entries and log rotation
+- **Explorer Context Menu**: Right-click any file to open or watch it in Slog Viewer
+- New commands: `Slog Viewer: Open Log File` and `Slog Viewer: Watch Log File (Live Tail)`
+
+### Changed
+- Extracted shared `processLogLine()` helper to eliminate duplicate parsing logic across debug adapter, task, and file log sources
+- Added bounded session log storage (FIFO eviction at 5000 entries) to prevent unbounded memory growth
+
+## [1.2.0] - 2026-02-17
+
+### Added
+- **VS Code Task support**: Run commands with `"type": "slogViewer"` in `tasks.json` to capture structured logs in the Slog Viewer panel while preserving terminal output
+- Task properties: `command`, `args`, `cwd`, `env` with VS Code variable substitution support
+
+## [1.1.3] - 2026-01-26
+
+### Added
+- **ECS (Elastic Common Schema) log format support**: Automatically detects and parses ECS-formatted logs alongside JSON and logfmt
+
+## [1.1.2] - 2025-12-30
+
+### Fixed
+- Fixed escaped quotes in logfmt string value parsing (Issue #1)
+- Fixed escaped backslashes in logfmt path values
+
+## [1.1.1] - 2025-12-01
+
+### Changed
+- Enhanced views configuration in `package.json`
+- Removed auto version bump from publish workflow
+
 ## [1.1.0] - 2025-12-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Beautiful structured log viewer for debugging. Automatically transforms JSON/log
 
 - **Automatic Detection**: Detects and formats JSON/logfmt logs during debugging
 - **Task Support**: Capture structured logs from VS Code Tasks (`"type": "slogViewer"`)
+- **Open Log Files**: View any structured log file directly in the panel, with optional live tail
 - **Interactive UI**: Modern webview with VSCode theme integration
 - **Advanced Filtering**: Click any field to include/exclude logs by value
 - **Filtering & Search**: Filter by log level and search across messages
@@ -19,6 +20,7 @@ Beautiful structured log viewer for debugging. Automatically transforms JSON/log
 1. Install the extension
 2. **Option A — Debugging**: Start debugging (F5) and view formatted logs in the **Slog Viewer** panel
 3. **Option B — Tasks**: Define a task with `"type": "slogViewer"` in `.vscode/tasks.json` and run it
+4. **Option C — Log Files**: Run **"Slog Viewer: Open Log File"** from the Command Palette, or right-click a file in the Explorer
 
 ## Task Support
 
@@ -74,6 +76,25 @@ VS Code Tasks let you run commands directly from VS Code. By using `"type": "slo
 | `env`     | No       | Additional environment variables      |
 
 Variable substitution is supported: `${workspaceFolder}`, `${file}`, `${env:VAR_NAME}`.
+
+## Log File Support
+
+Open any log file containing structured JSON or logfmt entries directly in the Slog Viewer panel.
+
+### Opening a Log File
+
+- **Command Palette**: Run `Slog Viewer: Open Log File` and select a file
+- **Explorer Context Menu**: Right-click any file and select **Open Log File** or **Watch Log File (Live Tail)**
+
+### Live Tail (Watch Mode)
+
+Use **"Slog Viewer: Watch Log File (Live Tail)"** to monitor a file for new log entries in real time. New lines appended to the file automatically appear in the panel. Log rotation (file truncation) is handled automatically.
+
+### Notes
+
+- Each file appears as a separate session in the session dropdown
+- Non-structured lines (plain text, stack traces) are silently skipped
+- Any text file with JSON or logfmt log lines is supported (`.log`, `.json`, `.jsonl`, `.txt`, etc.)
 
 ## Supported Formats
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "slog-viewer",
   "displayName": "Slog Viewer - JSON Log Formatter",
   "description": "Beautiful structured log viewer for debugging. Automatically formats JSON/logfmt logs with syntax highlighting, filtering, and search. Works with any language (Go slog, Node.js pino, Python structlog, etc.)",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "publisher": "hojabri",
   "icon": "icon.png",
   "repository": {
@@ -23,20 +23,66 @@
     "debug",
     "console",
     "structured-logging",
-    "tasks"
+    "tasks",
+    "log-viewer"
   ],
   "activationEvents": [
     "onDebug",
-    "onTaskType:slogViewer"
+    "onTaskType:slogViewer",
+    "onCommand:slog-viewer.openLogFile",
+    "onCommand:slog-viewer.watchLogFile"
   ],
   "main": "./dist/extension.js",
   "contributes": {
     "commands": [
       {
         "command": "slog-viewer.clearLogs",
-        "title": "Slog Viewer: Clear Logs"
+        "title": "Clear Logs",
+        "category": "Slog Viewer",
+        "icon": "$(clear-all)"
+      },
+      {
+        "command": "slog-viewer.openLogFile",
+        "title": "Open Log File",
+        "category": "Slog Viewer",
+        "icon": "$(file-text)"
+      },
+      {
+        "command": "slog-viewer.watchLogFile",
+        "title": "Watch Log File (Live Tail)",
+        "category": "Slog Viewer",
+        "icon": "$(eye)"
       }
     ],
+    "menus": {
+      "view/title": [
+        {
+          "command": "slog-viewer.openLogFile",
+          "when": "view == slog-viewer.logView",
+          "group": "navigation"
+        },
+        {
+          "command": "slog-viewer.watchLogFile",
+          "when": "view == slog-viewer.logView",
+          "group": "navigation"
+        },
+        {
+          "command": "slog-viewer.clearLogs",
+          "when": "view == slog-viewer.logView",
+          "group": "navigation"
+        }
+      ],
+      "explorer/context": [
+        {
+          "command": "slog-viewer.openLogFile",
+          "group": "navigation"
+        },
+        {
+          "command": "slog-viewer.watchLogFile",
+          "group": "navigation"
+        }
+      ]
+    },
     "viewsContainers": {
       "panel": [
         {
@@ -58,7 +104,7 @@
     "viewsWelcome": [
       {
         "view": "slog-viewer.logView",
-        "contents": "No logs yet.\n\nStart debugging or run a slogViewer task to see formatted structured logs.\n\n[Start Debugging](command:workbench.action.debug.start)"
+        "contents": "No logs yet.\n\nStart debugging, run a slogViewer task, or open a log file to see formatted structured logs here.\n\n[$(debug-alt) Start Debugging](command:workbench.action.debug.start)\n[$(file-text) Open Log File](command:slog-viewer.openLogFile)\n[$(eye) Watch Log File (Live Tail)](command:slog-viewer.watchLogFile)\n\nYou can also right-click any file in the Explorer to open or watch it."
       }
     ],
     "taskDefinitions": [

--- a/src/debugAdapterWrapper.ts
+++ b/src/debugAdapterWrapper.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { parseJSONLog, isJSONLog } from './logFormatter';
+import { processLogLine } from './logFormatter';
 import { SlogViewerWebviewProvider } from './webviewPanel';
 
 // Maximum number of recent lines to track for deduplication
@@ -58,18 +58,15 @@ export class SlogDebugAdapterTracker implements vscode.DebugAdapterTracker {
         }
       }
 
-      // Check if line is JSON/logfmt
-      if (isJSONLog(line)) {
-        const parsed = parseJSONLog(line);
-        if (parsed) {
-          // Send parsed log to webview with session ID
-          this.webviewProvider.addLog(this.sessionId, parsed);
+      // Check if line is a structured log (JSON/logfmt)
+      const parsed = processLogLine(line);
+      if (parsed) {
+        this.webviewProvider.addLog(this.sessionId, parsed);
 
-          // Auto-show the webview on first log
-          if (!this.hasShownWebview) {
-            this.webviewProvider.show();
-            this.hasShownWebview = true;
-          }
+        // Auto-show the webview on first log
+        if (!this.hasShownWebview) {
+          this.webviewProvider.show();
+          this.hasShownWebview = true;
         }
       }
       // Note: We only display structured logs in the webview.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import { SlogDebugAdapterTrackerFactory } from './debugAdapterWrapper';
 import { SlogViewerWebviewProvider } from './webviewPanel';
 import { SlogViewerTaskProvider } from './taskOutputTracker';
+import { FileLogLoader } from './fileLogLoader';
 
 let webviewProvider: SlogViewerWebviewProvider;
 
@@ -51,11 +52,27 @@ export function activate(context: vscode.ExtensionContext) {
     })
   );
 
+  // Register File Log Loader
+  const fileLogLoader = new FileLogLoader(webviewProvider);
+  context.subscriptions.push(fileLogLoader);
+
   // Register commands
   context.subscriptions.push(
     vscode.commands.registerCommand('slog-viewer.clearLogs', () => {
       webviewProvider.clearLogs();
       vscode.window.showInformationMessage('Slog Viewer: Logs cleared');
+    })
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand('slog-viewer.openLogFile', (uri?: vscode.Uri) => {
+      fileLogLoader.openFile(uri);
+    })
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand('slog-viewer.watchLogFile', (uri?: vscode.Uri) => {
+      fileLogLoader.openFile(uri, { watch: true });
     })
   );
 

--- a/src/fileLogLoader.test.ts
+++ b/src/fileLogLoader.test.ts
@@ -1,0 +1,448 @@
+import { EventEmitter } from 'events';
+
+// Mock vscode module
+jest.mock('vscode');
+
+// Mock fs module
+jest.mock('fs', () => {
+  const actual = jest.requireActual('fs');
+  return {
+    ...actual,
+    createReadStream: jest.fn(),
+    realpathSync: jest.fn((p: string) => p),
+    watch: jest.fn(),
+    statSync: jest.fn(),
+    promises: {
+      stat: jest.fn()
+    }
+  };
+});
+
+import * as fs from 'fs';
+import { FileLogLoader } from './fileLogLoader';
+
+// Helper: create a mock readable stream that emits data synchronously
+// once all event listeners are attached (via a microtask).
+function createMockReadStream(data: string): EventEmitter {
+  const stream = new EventEmitter();
+  (stream as any).destroy = jest.fn();
+  const origOn = stream.on.bind(stream);
+  let endScheduled = false;
+  stream.on = function(event: string, listener: (...args: any[]) => void) {
+    origOn(event, listener);
+    if (event === 'end' && !endScheduled) {
+      endScheduled = true;
+      // Use a microtask so the promise chain in readFile can resolve
+      Promise.resolve().then(() => {
+        stream.emit('data', data);
+        stream.emit('end');
+      });
+    }
+    return stream;
+  } as any;
+  return stream;
+}
+
+// Helper: create a mock watcher
+function createMockWatcher(): EventEmitter {
+  const watcher = new EventEmitter();
+  (watcher as any).close = jest.fn();
+  return watcher;
+}
+
+function createMockWebviewProvider() {
+  return {
+    addTaskSession: jest.fn(),
+    addLog: jest.fn(),
+    endSession: jest.fn(),
+    show: jest.fn(),
+    setCurrentSession: jest.fn(),
+    isSessionActive: jest.fn().mockReturnValue(false),
+    clearSessionLogs: jest.fn(),
+    clearLogs: jest.fn()
+  } as any;
+}
+
+// Helper to set up a watched file session by directly populating internal state.
+// This avoids async mock stream timing issues between tests.
+function setupWatchedSession(
+  loaderInst: FileLogLoader,
+  sessionId: string,
+  filePath: string,
+  options?: { withErrorHandler?: boolean; byteOffset?: number }
+): EventEmitter {
+  const mockWatcher = createMockWatcher();
+  const activeWatchers = (loaderInst as any).activeWatchers as Map<string, any>;
+  const fileSessionMap = (loaderInst as any).fileSessionMap as Map<string, string>;
+
+  if (options?.withErrorHandler) {
+    const vscode = require('vscode');
+    mockWatcher.on('error', (err: Error) => {
+      vscode.window.showErrorMessage(`File watcher error: ${err.message}`);
+      loaderInst.stopWatching(sessionId);
+    });
+  }
+
+  activeWatchers.set(sessionId, {
+    watcher: mockWatcher,
+    byteOffset: options?.byteOffset ?? 0,
+    lineBuffer: '',
+    filePath
+  });
+  fileSessionMap.set(filePath, sessionId);
+
+  return mockWatcher;
+}
+
+// Need to mock vscode.window.showOpenDialog and showErrorMessage
+const vscode = require('vscode');
+vscode.window = {
+  ...vscode.window,
+  showOpenDialog: jest.fn(),
+  showErrorMessage: jest.fn(),
+  showInformationMessage: jest.fn()
+};
+
+describe('FileLogLoader', () => {
+  let loader: FileLogLoader;
+  let mockProvider: ReturnType<typeof createMockWebviewProvider>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockProvider = createMockWebviewProvider();
+    loader = new FileLogLoader(mockProvider);
+  });
+
+  afterEach(async () => {
+    loader.dispose();
+    // Allow any pending async operations to complete
+    await new Promise(resolve => setTimeout(resolve, 10));
+  });
+
+  describe('openFile', () => {
+    it('should show file dialog when no URI provided', async () => {
+      vscode.window.showOpenDialog.mockResolvedValue(undefined);
+      await loader.openFile();
+      expect(vscode.window.showOpenDialog).toHaveBeenCalled();
+    });
+
+    it('should return early when dialog is cancelled', async () => {
+      vscode.window.showOpenDialog.mockResolvedValue(undefined);
+      await loader.openFile();
+      expect(mockProvider.addTaskSession).not.toHaveBeenCalled();
+    });
+
+    it('should return early when dialog returns empty array', async () => {
+      vscode.window.showOpenDialog.mockResolvedValue([]);
+      await loader.openFile();
+      expect(mockProvider.addTaskSession).not.toHaveBeenCalled();
+    });
+
+    it('should parse JSON log file correctly', async () => {
+      const logData = '{"time":"2025-01-01T00:00:00Z","level":"info","msg":"hello","port":8080}\n';
+      (fs.createReadStream as jest.Mock).mockReturnValue(createMockReadStream(logData));
+
+      const uri = { fsPath: '/tmp/test.log' } as any;
+      await loader.openFile(uri);
+
+      expect(mockProvider.addTaskSession).toHaveBeenCalledWith(
+        expect.stringMatching(/^file-/),
+        'File: test.log'
+      );
+      expect(mockProvider.addLog).toHaveBeenCalledTimes(1);
+      expect(mockProvider.addLog).toHaveBeenCalledWith(
+        expect.stringMatching(/^file-/),
+        expect.objectContaining({
+          level: 'INFO',
+          message: 'hello'
+        })
+      );
+      expect(mockProvider.endSession).toHaveBeenCalled();
+    });
+
+    it('should parse logfmt log file correctly', async () => {
+      const logData = 'time=2025-01-01T00:00:00Z level=info msg="server started" port=8080\n';
+      (fs.createReadStream as jest.Mock).mockReturnValue(createMockReadStream(logData));
+
+      const uri = { fsPath: '/tmp/test.log' } as any;
+      await loader.openFile(uri);
+
+      expect(mockProvider.addLog).toHaveBeenCalledTimes(1);
+      expect(mockProvider.addLog).toHaveBeenCalledWith(
+        expect.stringMatching(/^file-/),
+        expect.objectContaining({
+          level: 'INFO',
+          message: 'server started'
+        })
+      );
+    });
+
+    it('should skip non-structured lines', async () => {
+      const logData = [
+        'Starting server...',
+        '{"time":"2025-01-01T00:00:00Z","level":"info","msg":"ready"}',
+        'Some plain text',
+        '{"time":"2025-01-01T00:00:01Z","level":"error","msg":"failed"}',
+        ''
+      ].join('\n');
+      (fs.createReadStream as jest.Mock).mockReturnValue(createMockReadStream(logData));
+
+      const uri = { fsPath: '/tmp/mixed.log' } as any;
+      await loader.openFile(uri);
+
+      expect(mockProvider.addLog).toHaveBeenCalledTimes(2);
+    });
+
+    it('should flush incomplete last line on EOF', async () => {
+      // No trailing newline
+      const logData = '{"time":"2025-01-01T00:00:00Z","level":"info","msg":"no newline"}';
+      (fs.createReadStream as jest.Mock).mockReturnValue(createMockReadStream(logData));
+
+      const uri = { fsPath: '/tmp/test.log' } as any;
+      await loader.openFile(uri);
+
+      expect(mockProvider.addLog).toHaveBeenCalledTimes(1);
+      expect(mockProvider.addLog).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ message: 'no newline' })
+      );
+    });
+
+    it('should show info message for empty file', async () => {
+      (fs.createReadStream as jest.Mock).mockReturnValue(createMockReadStream(''));
+
+      const uri = { fsPath: '/tmp/empty.log' } as any;
+      await loader.openFile(uri);
+
+      expect(vscode.window.showInformationMessage).toHaveBeenCalledWith('No structured logs found in file.');
+      expect(mockProvider.endSession).toHaveBeenCalled();
+    });
+
+    it('should show info message for file with no structured logs', async () => {
+      const logData = 'just plain text\nno json here\n';
+      (fs.createReadStream as jest.Mock).mockReturnValue(createMockReadStream(logData));
+
+      const uri = { fsPath: '/tmp/plain.log' } as any;
+      await loader.openFile(uri);
+
+      expect(vscode.window.showInformationMessage).toHaveBeenCalledWith('No structured logs found in file.');
+    });
+
+    it('should handle file read error', async () => {
+      const stream = new EventEmitter();
+      (stream as any).destroy = jest.fn();
+      (fs.createReadStream as jest.Mock).mockReturnValue(stream);
+      process.nextTick(() => stream.emit('error', new Error('ENOENT')));
+
+      const uri = { fsPath: '/tmp/missing.log' } as any;
+      await loader.openFile(uri);
+
+      expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(expect.stringContaining('ENOENT'));
+      expect(mockProvider.endSession).toHaveBeenCalled();
+    });
+
+    it('should switch to existing active session for duplicate watched file', async () => {
+      // First open with watch (keeps fileSessionMap entry)
+      const logData = '{"time":"2025-01-01T00:00:00Z","level":"info","msg":"test"}\n';
+      (fs.createReadStream as jest.Mock).mockReturnValue(createMockReadStream(logData));
+      (fs.watch as jest.Mock).mockReturnValue(createMockWatcher());
+
+      const uri = { fsPath: '/tmp/test.log' } as any;
+      await loader.openFile(uri, { watch: true });
+
+      // Mark session as active for second open
+      mockProvider.isSessionActive.mockReturnValue(true);
+
+      // Second open of same file
+      await loader.openFile(uri);
+
+      // Should not create a second session
+      expect(mockProvider.addTaskSession).toHaveBeenCalledTimes(1);
+      expect(mockProvider.setCurrentSession).toHaveBeenCalled();
+    });
+
+    it('should create new session for stale (ended) watched file', async () => {
+      // First open with watch
+      const logData = '{"time":"2025-01-01T00:00:00Z","level":"info","msg":"test"}\n';
+      (fs.createReadStream as jest.Mock).mockReturnValue(createMockReadStream(logData));
+      (fs.watch as jest.Mock).mockReturnValue(createMockWatcher());
+
+      const uri = { fsPath: '/tmp/test.log' } as any;
+      await loader.openFile(uri, { watch: true });
+
+      // Session is not active (ended externally)
+      mockProvider.isSessionActive.mockReturnValue(false);
+
+      // Second open — should detect stale and create new session
+      (fs.createReadStream as jest.Mock).mockReturnValue(createMockReadStream(logData));
+      await loader.openFile(uri);
+
+      // Should create a second session
+      expect(mockProvider.addTaskSession).toHaveBeenCalledTimes(2);
+    });
+
+    it('should generate session IDs with file- prefix', async () => {
+      const logData = '{"time":"2025-01-01T00:00:00Z","level":"info","msg":"test"}\n';
+      (fs.createReadStream as jest.Mock).mockReturnValue(createMockReadStream(logData));
+
+      const uri = { fsPath: '/tmp/test.log' } as any;
+      await loader.openFile(uri);
+
+      const sessionId = mockProvider.addTaskSession.mock.calls[0][0];
+      expect(sessionId).toMatch(/^file-\d+-[a-z0-9]+$/);
+    });
+
+    it('should use Watch: prefix for session name when watching', async () => {
+      const logData = '{"time":"2025-01-01T00:00:00Z","level":"info","msg":"test"}\n';
+      (fs.createReadStream as jest.Mock).mockReturnValue(createMockReadStream(logData));
+      (fs.watch as jest.Mock).mockReturnValue(createMockWatcher());
+
+      const uri = { fsPath: '/tmp/test.log' } as any;
+      await loader.openFile(uri, { watch: true });
+
+      expect(mockProvider.addTaskSession).toHaveBeenCalledWith(
+        expect.any(String),
+        'Watch: test.log'
+      );
+      // Session should NOT be ended when watching
+      expect(mockProvider.endSession).not.toHaveBeenCalled();
+    });
+
+    it('should show error when realpathSync fails', async () => {
+      (fs.realpathSync as unknown as jest.Mock).mockImplementation(() => {
+        throw new Error('ENOENT');
+      });
+
+      const uri = { fsPath: '/tmp/nonexistent.log' } as any;
+      await loader.openFile(uri);
+
+      expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(expect.stringContaining('Cannot access file'));
+      expect(mockProvider.addTaskSession).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('watching', () => {
+    it('should handle watcher error event', () => {
+      const sessionId = 'file-test-error';
+      const mockWatcher = setupWatchedSession(loader, sessionId, '/tmp/test.log', { withErrorHandler: true });
+
+      mockWatcher.emit('error', new Error('File deleted'));
+
+      expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(expect.stringContaining('File deleted'));
+      expect(mockProvider.endSession).toHaveBeenCalledWith(sessionId);
+    });
+
+    it('should read appended bytes when file grows', async () => {
+      const sessionId = 'file-test-append';
+      setupWatchedSession(loader, sessionId, '/tmp/test.log', { byteOffset: 100 });
+
+      // Mock stat returning larger file
+      (fs.promises.stat as jest.Mock).mockResolvedValue({ size: 200 });
+
+      // Mock stream for appended bytes
+      const appendData = '{"time":"2025-01-01T00:00:01Z","level":"info","msg":"appended"}\n';
+      (fs.createReadStream as jest.Mock).mockReturnValue(createMockReadStream(appendData));
+
+      // Trigger onFileChanged directly
+      const state = (loader as any).activeWatchers.get(sessionId);
+      await (loader as any).onFileChanged(sessionId, state, '/tmp/test.log');
+
+      expect(fs.createReadStream).toHaveBeenCalledWith('/tmp/test.log', { start: 100 });
+      expect(mockProvider.addLog).toHaveBeenCalled();
+    });
+
+    it('should clear and re-read on file truncation (log rotation)', async () => {
+      const sessionId = 'file-test-rotation';
+      setupWatchedSession(loader, sessionId, '/tmp/test.log', { byteOffset: 500 });
+
+      // Mock stat returning smaller file (truncated)
+      (fs.promises.stat as jest.Mock).mockResolvedValue({ size: 50 });
+
+      // Mock stream for re-read
+      const newData = '{"time":"2025-01-01T00:00:02Z","level":"info","msg":"after rotation"}\n';
+      (fs.createReadStream as jest.Mock).mockReturnValue(createMockReadStream(newData));
+
+      const state = (loader as any).activeWatchers.get(sessionId);
+      await (loader as any).onFileChanged(sessionId, state, '/tmp/test.log');
+
+      expect(mockProvider.clearSessionLogs).toHaveBeenCalledWith(sessionId);
+      // Re-reads entire file (no start offset)
+      expect(fs.createReadStream).toHaveBeenCalledWith('/tmp/test.log', { encoding: 'utf8' });
+      expect(mockProvider.addLog).toHaveBeenCalled();
+    });
+
+    it('should skip when file size equals byte offset (metadata-only change)', async () => {
+      const sessionId = 'file-test-metadata';
+      setupWatchedSession(loader, sessionId, '/tmp/test.log', { byteOffset: 200 });
+
+      // Mock stat returning same size
+      (fs.promises.stat as jest.Mock).mockResolvedValue({ size: 200 });
+
+      const state = (loader as any).activeWatchers.get(sessionId);
+      await (loader as any).onFileChanged(sessionId, state, '/tmp/test.log');
+
+      expect(fs.createReadStream).not.toHaveBeenCalled();
+      expect(mockProvider.addLog).not.toHaveBeenCalled();
+    });
+
+    it('should guard against concurrent onFileChanged calls', async () => {
+      const sessionId = 'file-test-concurrent';
+      setupWatchedSession(loader, sessionId, '/tmp/test.log', { byteOffset: 100 });
+
+      // Mock stat and slow stream
+      (fs.promises.stat as jest.Mock).mockResolvedValue({ size: 200 });
+      const appendData = '{"time":"2025-01-01T00:00:01Z","level":"info","msg":"data"}\n';
+      (fs.createReadStream as jest.Mock).mockReturnValue(createMockReadStream(appendData));
+
+      const state = (loader as any).activeWatchers.get(sessionId);
+
+      // Fire two calls concurrently
+      const p1 = (loader as any).onFileChanged(sessionId, state, '/tmp/test.log');
+      const p2 = (loader as any).onFileChanged(sessionId, state, '/tmp/test.log');
+      await Promise.all([p1, p2]);
+
+      // Only one call should have created a stream (second was guarded)
+      expect(fs.createReadStream).toHaveBeenCalledTimes(1);
+    });
+
+    it('should stop watching on stat error', async () => {
+      const sessionId = 'file-test-stat-error';
+      setupWatchedSession(loader, sessionId, '/tmp/test.log', { byteOffset: 100 });
+
+      (fs.promises.stat as jest.Mock).mockRejectedValue(new Error('ENOENT'));
+
+      const state = (loader as any).activeWatchers.get(sessionId);
+      await (loader as any).onFileChanged(sessionId, state, '/tmp/test.log');
+
+      expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(expect.stringContaining('ENOENT'));
+      expect(mockProvider.endSession).toHaveBeenCalledWith(sessionId);
+    });
+  });
+
+  describe('dispose', () => {
+    it('should close all active watchers on dispose', () => {
+      const sessionId = 'file-test-dispose';
+      const mockWatcher = setupWatchedSession(loader, sessionId, '/tmp/test.log');
+
+      loader.dispose();
+
+      expect((mockWatcher as any).close).toHaveBeenCalled();
+      expect(mockProvider.endSession).toHaveBeenCalledWith(sessionId);
+    });
+
+    it('should clear debounce timers on dispose', () => {
+      const sessionId = 'file-test-debounce';
+      const mockWatcher = setupWatchedSession(loader, sessionId, '/tmp/test.log');
+
+      // Simulate a pending debounce timer
+      const state = (loader as any).activeWatchers.get(sessionId);
+      state.debounceTimer = setTimeout(() => {
+        throw new Error('Debounce timer should have been cleared');
+      }, 50);
+
+      loader.dispose();
+
+      expect((mockWatcher as any).close).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/fileLogLoader.ts
+++ b/src/fileLogLoader.ts
@@ -1,0 +1,336 @@
+import * as vscode from 'vscode';
+import * as fs from 'fs';
+import * as path from 'path';
+import { StringDecoder } from 'string_decoder';
+import { processLogLine, ParsedLog } from './logFormatter';
+import { processChunk } from './lineUtils';
+import { SlogViewerWebviewProvider } from './webviewPanel';
+
+// Batch size for addLog calls during bulk file reads
+const LOG_BATCH_SIZE = 100;
+
+// Debounce delay for file watch events (ms)
+const WATCH_DEBOUNCE_MS = 200;
+
+interface WatcherState {
+  watcher: fs.FSWatcher;
+  byteOffset: number;
+  lineBuffer: string;
+  debounceTimer?: ReturnType<typeof setTimeout>;
+  isProcessing?: boolean;
+  filePath: string;
+}
+
+/**
+ * Loads and optionally watches log files, displaying parsed structured logs
+ * in the slog-viewer webview panel.
+ */
+export class FileLogLoader implements vscode.Disposable {
+  private fileSessionMap: Map<string, string> = new Map(); // normalized filePath → sessionId
+  private activeWatchers: Map<string, WatcherState> = new Map(); // sessionId → watcher state
+
+  constructor(private webviewProvider: SlogViewerWebviewProvider) {}
+
+  /**
+   * Open a log file and display its structured logs in the webview.
+   * If watch is true, continue monitoring the file for new content.
+   */
+  public async openFile(fileUri?: vscode.Uri, options?: { watch?: boolean }): Promise<void> {
+    // Show file picker if no URI provided
+    if (!fileUri) {
+      const result = await vscode.window.showOpenDialog({
+        canSelectMany: false,
+        filters: {
+          'Log Files': ['log', 'json', 'jsonl', 'txt'],
+          'All Files': ['*']
+        }
+      });
+      if (!result || result.length === 0) {
+        return;
+      }
+      fileUri = result[0];
+    }
+
+    const filePath = fileUri.fsPath;
+
+    // Normalize path for dedup (resolve symlinks and canonical path)
+    let normalizedPath: string;
+    try {
+      normalizedPath = fs.realpathSync(filePath);
+    } catch {
+      vscode.window.showErrorMessage(`Cannot access file: ${filePath}`);
+      return;
+    }
+
+    // Check if file is already open
+    const existingSessionId = this.fileSessionMap.get(normalizedPath);
+    if (existingSessionId) {
+      if (this.webviewProvider.isSessionActive(existingSessionId)) {
+        // Switch to existing active session
+        this.webviewProvider.setCurrentSession(existingSessionId);
+        this.webviewProvider.show();
+        return;
+      }
+      // Stale session — remove and proceed to create new one
+      this.fileSessionMap.delete(normalizedPath);
+    }
+
+    const watch = options?.watch === true;
+    const sessionId = `file-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
+    const basename = path.basename(filePath);
+    const sessionName = watch ? `Watch: ${basename}` : `File: ${basename}`;
+
+    // Register session
+    this.fileSessionMap.set(normalizedPath, sessionId);
+    this.webviewProvider.addTaskSession(sessionId, sessionName);
+    this.webviewProvider.show();
+
+    // Read and parse the file
+    try {
+      const byteOffset = await this.readFile(filePath, sessionId);
+
+      if (watch) {
+        this.startWatching(sessionId, normalizedPath, filePath, byteOffset);
+      } else {
+        this.webviewProvider.endSession(sessionId);
+        // Remove from map so file can be reopened
+        this.fileSessionMap.delete(normalizedPath);
+      }
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      this.webviewProvider.endSession(sessionId);
+      this.fileSessionMap.delete(normalizedPath);
+      vscode.window.showErrorMessage(`Error reading log file: ${msg}`);
+    }
+  }
+
+  /**
+   * Parse a line and add to batch, flushing when batch is full.
+   */
+  private addToBatch(line: string, batch: ParsedLog[], sessionId: string): boolean {
+    const parsed = processLogLine(line);
+    if (parsed) {
+      batch.push(parsed);
+      if (batch.length >= LOG_BATCH_SIZE) {
+        this.flushBatch(batch, sessionId);
+      }
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Read a file from start, parsing structured logs.
+   * Returns the total bytes read.
+   */
+  private readFile(filePath: string, sessionId: string): Promise<number> {
+    return new Promise((resolve, reject) => {
+      let lineBuffer = '';
+      let logCount = 0;
+      let totalBytes = 0;
+      const batch: ParsedLog[] = [];
+
+      const stream = fs.createReadStream(filePath, { encoding: 'utf8' });
+
+      stream.on('data', (data: string | Buffer) => {
+        const str = data.toString();
+        totalBytes += Buffer.byteLength(str, 'utf8');
+
+        lineBuffer = processChunk(str, lineBuffer, (line) => {
+          if (this.addToBatch(line, batch, sessionId)) {
+            logCount++;
+          }
+        });
+      });
+
+      stream.on('end', () => {
+        // Flush remaining line buffer
+        if (lineBuffer.trim()) {
+          if (this.addToBatch(lineBuffer, batch, sessionId)) {
+            logCount++;
+          }
+        }
+
+        // Flush remaining batch
+        this.flushBatch(batch, sessionId);
+
+        if (logCount === 0) {
+          vscode.window.showInformationMessage('No structured logs found in file.');
+        }
+
+        resolve(totalBytes);
+      });
+
+      stream.on('error', (err) => {
+        // Flush any logs we did parse before the error
+        this.flushBatch(batch, sessionId);
+        stream.destroy();
+        reject(err);
+      });
+    });
+  }
+
+  /**
+   * Read new bytes appended to a watched file.
+   * Uses StringDecoder to safely handle UTF-8 multi-byte characters at byte boundaries.
+   */
+  private readAppendedBytes(filePath: string, sessionId: string, watcherState: WatcherState): Promise<number> {
+    return new Promise((resolve, reject) => {
+      let newBytes = 0;
+      const decoder = new StringDecoder('utf8');
+      const batch: ParsedLog[] = [];
+
+      const stream = fs.createReadStream(filePath, { start: watcherState.byteOffset });
+
+      stream.on('data', (chunk: string | Buffer) => {
+        const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+        newBytes += buf.length;
+        const data = decoder.write(buf);
+
+        watcherState.lineBuffer = processChunk(data, watcherState.lineBuffer, (line) => {
+          this.addToBatch(line, batch, sessionId);
+        });
+      });
+
+      stream.on('end', () => {
+        // Flush any remaining bytes from the decoder
+        const remaining = decoder.end();
+        if (remaining) {
+          watcherState.lineBuffer = processChunk(remaining, watcherState.lineBuffer, (line) => {
+            this.addToBatch(line, batch, sessionId);
+          });
+        }
+
+        this.flushBatch(batch, sessionId);
+        resolve(newBytes);
+      });
+
+      stream.on('error', (err) => {
+        this.flushBatch(batch, sessionId);
+        stream.destroy();
+        reject(err);
+      });
+    });
+  }
+
+  /**
+   * Flush a batch of parsed logs to the webview.
+   * Clears the batch array in-place for reuse by the caller.
+   */
+  private flushBatch(batch: ParsedLog[], sessionId: string): void {
+    for (const log of batch) {
+      this.webviewProvider.addLog(sessionId, log);
+    }
+    batch.length = 0;
+  }
+
+  /**
+   * Start watching a file for changes
+   */
+  private startWatching(sessionId: string, normalizedPath: string, filePath: string, byteOffset: number): void {
+    const watcherState: WatcherState = {
+      watcher: null!,
+      byteOffset,
+      lineBuffer: '',
+      filePath
+    };
+
+    try {
+      const watcher = fs.watch(filePath);
+
+      watcher.on('change', () => {
+        // Debounce rapid change events
+        if (watcherState.debounceTimer) {
+          clearTimeout(watcherState.debounceTimer);
+        }
+        watcherState.debounceTimer = setTimeout(() => {
+          this.onFileChanged(sessionId, watcherState, normalizedPath);
+        }, WATCH_DEBOUNCE_MS);
+      });
+
+      watcher.on('error', (err) => {
+        vscode.window.showErrorMessage(`File watcher error: ${err.message}`);
+        this.stopWatching(sessionId);
+      });
+
+      watcherState.watcher = watcher;
+      this.activeWatchers.set(sessionId, watcherState);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      vscode.window.showErrorMessage(`Could not watch file: ${msg}`);
+      this.webviewProvider.endSession(sessionId);
+      this.fileSessionMap.delete(normalizedPath);
+    }
+  }
+
+  /**
+   * Handle a debounced file change event.
+   * Uses isProcessing guard to prevent concurrent reads from overlapping.
+   */
+  private async onFileChanged(sessionId: string, watcherState: WatcherState, normalizedPath: string): Promise<void> {
+    if (watcherState.isProcessing) {
+      return;
+    }
+    watcherState.isProcessing = true;
+
+    try {
+      const stat = await fs.promises.stat(watcherState.filePath);
+      const newSize = stat.size;
+
+      if (newSize < watcherState.byteOffset) {
+        // Log rotation — file was truncated. Clear and re-read.
+        this.webviewProvider.clearSessionLogs(sessionId);
+        watcherState.byteOffset = 0;
+        watcherState.lineBuffer = '';
+        const totalBytes = await this.readFile(watcherState.filePath, sessionId);
+        watcherState.byteOffset = totalBytes;
+      } else if (newSize > watcherState.byteOffset) {
+        // New data appended — read only new bytes
+        const newBytes = await this.readAppendedBytes(watcherState.filePath, sessionId, watcherState);
+        watcherState.byteOffset += newBytes;
+      }
+      // If newSize === byteOffset, nothing changed (e.g., metadata change)
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      vscode.window.showErrorMessage(`Error reading watched file: ${msg}`);
+      this.stopWatching(sessionId);
+    } finally {
+      watcherState.isProcessing = false;
+    }
+  }
+
+  /**
+   * Stop watching a file and end its session
+   */
+  public stopWatching(sessionId: string): void {
+    const state = this.activeWatchers.get(sessionId);
+    if (state) {
+      if (state.debounceTimer) {
+        clearTimeout(state.debounceTimer);
+      }
+      state.watcher.close();
+      this.activeWatchers.delete(sessionId);
+
+      // Remove from file-session map
+      for (const [path, sid] of this.fileSessionMap) {
+        if (sid === sessionId) {
+          this.fileSessionMap.delete(path);
+          break;
+        }
+      }
+    }
+
+    this.webviewProvider.endSession(sessionId);
+  }
+
+  /**
+   * Dispose all watchers and clean up
+   */
+  public dispose(): void {
+    const sessionIds = Array.from(this.activeWatchers.keys());
+    for (const sessionId of sessionIds) {
+      this.stopWatching(sessionId);
+    }
+    this.fileSessionMap.clear();
+  }
+}

--- a/src/lineUtils.ts
+++ b/src/lineUtils.ts
@@ -1,0 +1,36 @@
+/**
+ * Shared line-processing utilities used by task output tracker and file log loader.
+ */
+
+/**
+ * Process a data chunk with line buffering, calling onLine for each complete line.
+ * Returns the remaining incomplete line (to be buffered for the next chunk).
+ */
+export function processChunk(
+  data: string,
+  lineBuffer: string,
+  onLine: (line: string) => void
+): string {
+  const combined = lineBuffer + data;
+  const lines = combined.split('\n');
+
+  // The last element is either an incomplete line or empty string
+  const remaining = lines.pop() ?? '';
+
+  for (const line of lines) {
+    // Strip trailing \r for Windows-style line endings
+    const cleaned = line.replace(/\r$/, '');
+    if (cleaned.trim()) {
+      onLine(cleaned);
+    }
+  }
+
+  return remaining;
+}
+
+/**
+ * Normalize line endings for terminal display: convert all line endings to \r\n
+ */
+export function normalizeLineEndings(data: string): string {
+  return data.replace(/\r\n|\r|\n/g, '\r\n');
+}

--- a/src/logFormatter.ts
+++ b/src/logFormatter.ts
@@ -332,6 +332,18 @@ export function formatLog(parsed: ParsedLog, config: vscode.WorkspaceConfigurati
 }
 
 /**
+ * Try to parse a line as a structured log (JSON or logfmt).
+ * Returns ParsedLog if the line is a structured log, null otherwise.
+ * This is the shared entry point used by all log sources (debug adapter, tasks, file loader).
+ */
+export function processLogLine(line: string): ParsedLog | null {
+  if (!isJSONLog(line)) {
+    return null;
+  }
+  return parseJSONLog(line);
+}
+
+/**
  * Process a line from the debug console output
  * Returns formatted output if it's a JSON log, otherwise returns null
  */

--- a/src/taskOutputTracker.ts
+++ b/src/taskOutputTracker.ts
@@ -1,7 +1,11 @@
 import * as vscode from 'vscode';
 import * as cp from 'child_process';
-import { isJSONLog, parseJSONLog } from './logFormatter';
+import { processLogLine } from './logFormatter';
+import { processChunk, normalizeLineEndings } from './lineUtils';
 import { SlogViewerWebviewProvider } from './webviewPanel';
+
+// Re-export for backwards compatibility (used by fileLogLoader and tests)
+export { processChunk, normalizeLineEndings };
 
 // Maximum number of recent lines to track for deduplication
 const MAX_PROCESSED_LINES = 1000;
@@ -32,39 +36,6 @@ export function resolveVariables(value: string, folder?: vscode.WorkspaceFolder)
   });
 
   return result;
-}
-
-/**
- * Process a data chunk with line buffering, calling onLine for each complete line.
- * Returns the remaining incomplete line (to be buffered for the next chunk).
- */
-export function processChunk(
-  data: string,
-  lineBuffer: string,
-  onLine: (line: string) => void
-): string {
-  const combined = lineBuffer + data;
-  const lines = combined.split('\n');
-
-  // The last element is either an incomplete line or empty string
-  const remaining = lines.pop() ?? '';
-
-  for (const line of lines) {
-    // Strip trailing \r for Windows-style line endings
-    const cleaned = line.replace(/\r$/, '');
-    if (cleaned.trim()) {
-      onLine(cleaned);
-    }
-  }
-
-  return remaining;
-}
-
-/**
- * Normalize line endings for terminal display: convert all line endings to \r\n
- */
-export function normalizeLineEndings(data: string): string {
-  return data.replace(/\r\n|\r|\n/g, '\r\n');
 }
 
 /**
@@ -215,16 +186,14 @@ class SlogViewerPseudoterminal implements vscode.Pseudoterminal {
       }
     }
 
-    if (isJSONLog(line)) {
-      const parsed = parseJSONLog(line);
-      if (parsed) {
-        this.webviewProvider.addLog(this.sessionId, parsed);
+    const parsed = processLogLine(line);
+    if (parsed) {
+      this.webviewProvider.addLog(this.sessionId, parsed);
 
-        // Auto-show the webview on first structured log
-        if (!this.hasShownWebview) {
-          this.webviewProvider.show();
-          this.hasShownWebview = true;
-        }
+      // Auto-show the webview on first structured log
+      if (!this.hasShownWebview) {
+        this.webviewProvider.show();
+        this.hasShownWebview = true;
       }
     }
   }

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -106,7 +106,14 @@
             <div class="empty-state">
                 <div class="empty-icon">📋</div>
                 <p>No logs yet</p>
-                <small>Start debugging or run a slogViewer task to see formatted logs</small>
+                <small>Get started with any of these options:</small>
+                <ul class="empty-hints">
+                    <li>Press <kbd>F5</kbd> to start debugging — structured logs appear here automatically</li>
+                    <li>Use the <strong>Open File</strong> button above to view a log file</li>
+                    <li>Use the <strong>Watch File</strong> button above for live tailing</li>
+                    <li>Right-click any file in the Explorer for quick access</li>
+                    <li>Add <code>"type": "slogViewer"</code> to tasks.json to capture task output</li>
+                </ul>
             </div>
         </div>
     </div>

--- a/src/webview/styles.css
+++ b/src/webview/styles.css
@@ -424,6 +424,37 @@ body {
     opacity: 0.7;
 }
 
+.empty-hints {
+    list-style: none;
+    padding: 0;
+    margin: 12px 0 0 0;
+    text-align: left;
+    font-size: 12px;
+    line-height: 2;
+}
+
+.empty-hints li::before {
+    content: "›";
+    margin-right: 8px;
+    opacity: 0.5;
+}
+
+.empty-hints kbd {
+    padding: 1px 5px;
+    border: 1px solid var(--border-color, #555);
+    border-radius: 3px;
+    font-size: 11px;
+    font-family: inherit;
+    background: var(--input-background, #333);
+}
+
+.empty-hints code {
+    padding: 1px 4px;
+    border-radius: 3px;
+    font-size: 11px;
+    background: var(--input-background, #333);
+}
+
 /* Log entry */
 .log-entry {
     margin-bottom: 4px;

--- a/src/webviewPanel.ts
+++ b/src/webviewPanel.ts
@@ -11,6 +11,9 @@ import { ExtensionMessage, WebviewConfig, SessionInfo } from './messageTypes';
 // Maximum number of logs to buffer before webview is ready
 const MAX_PENDING_LOGS = 500;
 
+// Maximum number of logs to keep per session (matches webview-side MAX_LOGS)
+const MAX_SESSION_LOGS = 5000;
+
 // Internal session data including logs
 interface SessionData extends SessionInfo {
   logs: ParsedLog[];
@@ -92,10 +95,13 @@ export class SlogViewerWebviewProvider implements vscode.WebviewViewProvider {
    * Add a log entry to the webview for a specific session
    */
   public addLog(sessionId: string, log: ParsedLog): void {
-    // Store log in the session data
+    // Store log in the session data with FIFO eviction
     const session = this.sessions.get(sessionId);
     if (session) {
       session.logs.push(log);
+      while (session.logs.length > MAX_SESSION_LOGS) {
+        session.logs.shift();
+      }
     }
 
     // Buffer logs if webview isn't ready yet
@@ -163,7 +169,7 @@ export class SlogViewerWebviewProvider implements vscode.WebviewViewProvider {
   }
 
   /**
-   * Add a new task session (not tied to a debug session)
+   * Add a non-debug session (task output, file log, etc.)
    */
   public addTaskSession(id: string, name: string): void {
     const sessionData: SessionData = { id, name, isActive: true, logs: [] };
@@ -190,6 +196,34 @@ export class SlogViewerWebviewProvider implements vscode.WebviewViewProvider {
     if (this.sessions.has(sessionId)) {
       this.currentSessionId = sessionId;
       this.sendSessionsToWebview();
+    }
+  }
+
+  /**
+   * Check if a session exists and is active
+   */
+  public isSessionActive(sessionId: string): boolean {
+    const session = this.sessions.get(sessionId);
+    return session?.isActive === true;
+  }
+
+  /**
+   * Clear logs for a specific session by ID
+   */
+  public clearSessionLogs(sessionId: string): void {
+    // Clear pending logs for this session
+    this.pendingLogs = this.pendingLogs.filter(p => p.sessionId !== sessionId);
+
+    // Clear logs in session data
+    const session = this.sessions.get(sessionId);
+    if (session) {
+      session.logs = [];
+    }
+
+    // If this is the current session, also clear the webview
+    if (sessionId === this.currentSessionId && this.view) {
+      const message: ExtensionMessage = { type: 'clearLogs' };
+      this.view.webview.postMessage(message);
     }
   }
 


### PR DESCRIPTION
## Summary
- Open any structured log file (JSON/logfmt) directly in the Slog Viewer panel
- Watch log files in real time with live tail and automatic log rotation handling
- Toolbar buttons on the panel header for Open File, Watch File, and Clear Logs
- Explorer context menu integration (right-click any file)
- Improved empty state with getting-started hints
- Extracted shared `processLogLine()` and `processChunk` utilities (DRY cleanup)
- Added bounded session log storage (FIFO eviction at 5000 entries)
- Race condition guard for concurrent file change events
- 66 tests passing (5 new watch-mode tests)

Closes #5
