### PR TITLE
Add autoReveal setting to control panel auto-focus

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,10 +127,13 @@ time=2025-01-01T00:00:00Z level=info msg="Server started" port=8080
 
 Access via VSCode Settings → "Slog Viewer":
 
-- Toggle automatic formatting
-- Collapse JSON by default
-- Auto-scroll to latest logs
-- Theme: light, dark, or auto
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `slogViewer.autoReveal` | `true` | Automatically reveal the panel when the first structured log is detected. Set to `false` to open the panel manually. |
+| `slogViewer.collapseJSON` | `true` | Show JSON collapsed by default (click to expand) |
+| `slogViewer.showRawJSON` | `false` | Show the raw JSON log below each formatted entry |
+| `slogViewer.autoScroll` | `true` | Automatically scroll to the latest log entry |
+| `slogViewer.theme` | `auto` | Theme for the log viewer (`light`, `dark`, or `auto`) |
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "slog-viewer",
   "displayName": "Slog Viewer - JSON Log Formatter",
   "description": "Beautiful structured log viewer for debugging. Automatically formats JSON/logfmt logs with syntax highlighting, filtering, and search. Works with any language (Go slog, Node.js pino, Python structlog, etc.)",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "publisher": "hojabri",
   "icon": "icon.png",
   "repository": {
@@ -187,6 +187,11 @@
           ],
           "default": "auto",
           "description": "Theme for the log viewer (auto uses VSCode theme)"
+        },
+        "slogViewer.autoReveal": {
+          "type": "boolean",
+          "default": true,
+          "description": "Automatically reveal the Slog Viewer panel when the first structured log is detected. When disabled, open the panel manually."
         }
       }
     }

--- a/src/debugAdapterWrapper.ts
+++ b/src/debugAdapterWrapper.ts
@@ -65,7 +65,7 @@ export class SlogDebugAdapterTracker implements vscode.DebugAdapterTracker {
 
         // Auto-show the webview on first log
         if (!this.hasShownWebview) {
-          this.webviewProvider.show();
+          this.webviewProvider.autoShow();
           this.hasShownWebview = true;
         }
       }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -42,7 +42,6 @@ export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.debug.onDidStartDebugSession((session) => {
       webviewProvider.addSession(session);
-      webviewProvider.show();
     })
   );
 

--- a/src/taskOutputTracker.ts
+++ b/src/taskOutputTracker.ts
@@ -192,7 +192,7 @@ class SlogViewerPseudoterminal implements vscode.Pseudoterminal {
 
       // Auto-show the webview on first structured log
       if (!this.hasShownWebview) {
-        this.webviewProvider.show();
+        this.webviewProvider.autoShow();
         this.hasShownWebview = true;
       }
     }
@@ -247,7 +247,6 @@ export class SlogViewerTaskProvider implements vscode.TaskProvider {
     const execution = new vscode.CustomExecution(async () => {
       // Create the task session in the webview
       webviewProvider.addTaskSession(sessionId, sessionName);
-      webviewProvider.show();
 
       return new SlogViewerPseudoterminal(
         resolvedCommand,

--- a/src/webviewPanel.ts
+++ b/src/webviewPanel.ts
@@ -297,6 +297,16 @@ export class SlogViewerWebviewProvider implements vscode.WebviewViewProvider {
   }
 
   /**
+   * Auto-show the panel if the autoReveal setting is enabled.
+   */
+  public autoShow(): void {
+    const config = vscode.workspace.getConfiguration('slogViewer');
+    if (config.get<boolean>('autoReveal', true)) {
+      this.show();
+    }
+  }
+
+  /**
    * Show QuickPick for export format + destination selection.
    * Called from toolbar button (via requestExport message) or from registered commands.
    */


### PR DESCRIPTION
## Summary
- Adds `slogViewer.autoReveal` boolean setting (default `true`) to control whether the panel automatically reveals when structured logs are detected
- When `false`, the panel never auto-opens — users open it manually
- Panel now only auto-reveals on first structured log (not on session start), avoiding showing an empty panel
- Explicit user actions (Open/Watch Log File) always show the panel regardless of this setting
- Updates README with a complete settings table

Closes #11