### PR TITLE
Fix explorer context menu placement (Issue #13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the "Slog Viewer" extension will be documented in this file.
 
+## [1.5.1] - 2026-03-17
+
+### Fixed
+- Explorer context menu items no longer appear at the top of the menu (Issue #13)
+- Context menu now only shows for relevant file types (`.log`, `.json`, `.jsonl`, `.txt`, `.ndjson`)
+
+### Changed
+- Renamed "Open Log File" to "Open in Slog Viewer" for clarity
+- Renamed "Watch Log File (Live Tail)" to "Watch in Slog Viewer (Live Tail)" for clarity
+
 ## [1.4.0] - 2026-03-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Beautiful structured log viewer for debugging. Automatically transforms JSON/log
 1. Install the extension
 2. **Option A — Debugging**: Start debugging (F5) and view formatted logs in the **Slog Viewer** panel
 3. **Option B — Tasks**: Define a task with `"type": "slogViewer"` in `.vscode/tasks.json` and run it
-4. **Option C — Log Files**: Run **"Slog Viewer: Open Log File"** from the Command Palette, or right-click a file in the Explorer
+4. **Option C — Log Files**: Run **"Slog Viewer: Open in Slog Viewer"** from the Command Palette, or right-click a file in the Explorer
 
 ## Task Support
 
@@ -84,12 +84,12 @@ Open any log file containing structured JSON or logfmt entries directly in the S
 
 ### Opening a Log File
 
-- **Command Palette**: Run `Slog Viewer: Open Log File` and select a file
-- **Explorer Context Menu**: Right-click any file and select **Open Log File** or **Watch Log File (Live Tail)**
+- **Command Palette**: Run `Slog Viewer: Open in Slog Viewer` and select a file
+- **Explorer Context Menu**: Right-click a log file and select **Open in Slog Viewer** or **Watch in Slog Viewer (Live Tail)**
 
 ### Live Tail (Watch Mode)
 
-Use **"Slog Viewer: Watch Log File (Live Tail)"** to monitor a file for new log entries in real time. New lines appended to the file automatically appear in the panel. Log rotation (file truncation) is handled automatically.
+Use **"Slog Viewer: Watch in Slog Viewer (Live Tail)"** to monitor a file for new log entries in real time. New lines appended to the file automatically appear in the panel. Log rotation (file truncation) is handled automatically.
 
 ### Notes
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "slog-viewer",
   "displayName": "Slog Viewer - JSON Log Formatter",
   "description": "Beautiful structured log viewer for debugging. Automatically formats JSON/logfmt logs with syntax highlighting, filtering, and search. Works with any language (Go slog, Node.js pino, Python structlog, etc.)",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "publisher": "hojabri",
   "icon": "icon.png",
   "repository": {
@@ -43,13 +43,13 @@
       },
       {
         "command": "slog-viewer.openLogFile",
-        "title": "Open Log File",
+        "title": "Open in Slog Viewer",
         "category": "Slog Viewer",
         "icon": "$(file-text)"
       },
       {
         "command": "slog-viewer.watchLogFile",
-        "title": "Watch Log File (Live Tail)",
+        "title": "Watch in Slog Viewer (Live Tail)",
         "category": "Slog Viewer",
         "icon": "$(eye)"
       },
@@ -99,11 +99,13 @@
       "explorer/context": [
         {
           "command": "slog-viewer.openLogFile",
-          "group": "navigation"
+          "when": "resourceExtname =~ /\\.(log|json|jsonl|txt|ndjson)$/",
+          "group": "slogviewer@1"
         },
         {
           "command": "slog-viewer.watchLogFile",
-          "group": "navigation"
+          "when": "resourceExtname =~ /\\.(log|json|jsonl|txt|ndjson)$/",
+          "group": "slogviewer@2"
         }
       ]
     },
@@ -128,7 +130,7 @@
     "viewsWelcome": [
       {
         "view": "slog-viewer.logView",
-        "contents": "No logs yet.\n\nStart debugging, run a slogViewer task, or open a log file to see formatted structured logs here.\n\n[$(debug-alt) Start Debugging](command:workbench.action.debug.start)\n[$(file-text) Open Log File](command:slog-viewer.openLogFile)\n[$(eye) Watch Log File (Live Tail)](command:slog-viewer.watchLogFile)\n\nYou can also right-click any file in the Explorer to open or watch it."
+        "contents": "No logs yet.\n\nStart debugging, run a slogViewer task, or open a log file to see formatted structured logs here.\n\n[$(debug-alt) Start Debugging](command:workbench.action.debug.start)\n[$(file-text) Open in Slog Viewer](command:slog-viewer.openLogFile)\n[$(eye) Watch in Slog Viewer (Live Tail)](command:slog-viewer.watchLogFile)\n\nYou can also right-click a log file in the Explorer to open or watch it."
       }
     ],
     "taskDefinitions": [


### PR DESCRIPTION
## Summary
- Move explorer context menu items from `navigation` group (top) to a custom group (bottom), so they no longer appear above "New File..."
- Restrict context menu to relevant file types (`.log`, `.json`, `.jsonl`, `.txt`, `.ndjson`)
- Rename commands to "Open in Slog Viewer" / "Watch in Slog Viewer" for clarity
- Bump version to 1.5.1

Fixes #13