### PR TITLE
Improve log entry click UX and reduce line spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the "Slog Viewer" extension will be documented in this file.
 
+## [1.6.0] - 2026-04-01
+
+### Changed
+- **Improved click UX**: Left-click on a log entry now expands/collapses it; right-click opens the filter context menu (include/exclude/copy)
+- **Open file via context menu**: Right-clicking a file path field now shows an "Open file" option alongside filter actions
+- **Compact log spacing**: Reduced vertical spacing between log entries for a denser, more scannable view
+
 ## [1.5.1] - 2026-03-17
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ Beautiful structured log viewer for debugging. Automatically transforms JSON/log
 - **Task Support**: Capture structured logs from VS Code Tasks (`"type": "slogViewer"`)
 - **Open Log Files**: View any structured log file directly in the panel, with optional live tail
 - **Interactive UI**: Modern webview with VSCode theme integration
-- **Advanced Filtering**: Click any field to include/exclude logs by value
+- **Advanced Filtering**: Right-click any field to include/exclude logs by value
 - **Filtering & Search**: Filter by log level and search across messages
 - **Export Logs**: Copy or save filtered logs as JSON, CSV, or text
-- **Collapsible Fields**: Click to expand/collapse JSON
+- **Collapsible Fields**: Click to expand/collapse log details
 - **Works with Any Language**: Go slog, Node.js pino, Python structlog, and more
 
 ## Quick Start
@@ -112,7 +112,7 @@ time=2025-01-01T00:00:00Z level=info msg="Server started" port=8080
 ## Advanced Filtering
 
 
-1. **Click any value** - Click on a log message or any JSON field value to open the filter menu
+1. **Right-click any value** - Right-click on a log message or any JSON field value to open the filter menu
 2. **Include/Exclude** - Choose to show only logs with that value, or hide logs with that value
 3. **Filter chips** - Active filters appear as chips below the toolbar
    - Green chips = include filters
@@ -121,7 +121,7 @@ time=2025-01-01T00:00:00Z level=info msg="Server started" port=8080
    - Click × to remove a filter
 4. **Add Filter button** - Manually create filters for any field
 
-**Example**: To hide all "http request" logs, click on a message containing "http request" and select "Exclude".
+**Example**: To hide all "http request" logs, right-click on a message containing "http request" and select "Exclude".
 
 ## Configuration
 
@@ -130,7 +130,7 @@ Access via VSCode Settings → "Slog Viewer":
 | Setting | Default | Description |
 |---------|---------|-------------|
 | `slogViewer.autoReveal` | `true` | Automatically reveal the panel when the first structured log is detected. Set to `false` to open the panel manually. |
-| `slogViewer.collapseJSON` | `true` | Show JSON collapsed by default (click to expand) |
+| `slogViewer.collapseJSON` | `true` | Show log details collapsed by default (click to expand) |
 | `slogViewer.showRawJSON` | `false` | Show the raw JSON log below each formatted entry |
 | `slogViewer.autoScroll` | `true` | Automatically scroll to the latest log entry |
 | `slogViewer.theme` | `auto` | Theme for the log viewer (`light`, `dark`, or `auto`) |

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "slog-viewer",
   "displayName": "Slog Viewer - JSON Log Formatter",
   "description": "Beautiful structured log viewer for debugging. Automatically formats JSON/logfmt logs with syntax highlighting, filtering, and search. Works with any language (Go slog, Node.js pino, Python structlog, etc.)",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "publisher": "hojabri",
   "icon": "icon.png",
   "repository": {

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -94,6 +94,10 @@
 
         <!-- Context Menu (hidden, positioned absolutely) -->
         <div class="context-menu hidden" id="contextMenu">
+            <div class="context-menu-item hidden" data-action="open_file" id="contextMenuOpenFile">
+                <span class="menu-icon">→</span> Open file
+            </div>
+            <div class="context-menu-separator hidden" id="contextMenuFileSeparator"></div>
             <div class="context-menu-item" data-action="include">
                 <span class="menu-icon">+</span> Include this value
             </div>

--- a/src/webview/styles.css
+++ b/src/webview/styles.css
@@ -457,7 +457,7 @@ body {
 
 /* Log entry */
 .log-entry {
-    margin-bottom: 4px;
+    margin-bottom: 1px;
     border-left: 3px solid var(--border-color);
     padding-left: 8px;
 }
@@ -499,7 +499,7 @@ body {
     align-items: center;
     gap: 8px;
     cursor: pointer;
-    padding: 4px 0;
+    padding: 2px 0;
     user-select: none;
 }
 

--- a/src/webview/webview.js
+++ b/src/webview/webview.js
@@ -25,7 +25,7 @@ let autoScrollActive = true;
 let activeFilters = [];  // Array of FilterCondition objects
 let availableFields = new Set(['message', 'level']);  // Discovered fields from logs
 let filterIdCounter = 0;  // For generating unique filter IDs
-let contextMenuTarget = null;  // { field, value } for context menu actions
+let contextMenuTarget = null;  // { field, value, fileInfo? } for context menu actions
 
 // Filter operators
 const FILTER_OPERATORS = {
@@ -505,8 +505,9 @@ function createLogElement(log, index) {
     const message = document.createElement('span');
     message.className = 'log-message filterable';
     message.textContent = log.message;
-    // Add click handler for filtering by message
-    message.addEventListener('click', (e) => {
+    // Right-click handler for filtering by message
+    message.addEventListener('contextmenu', (e) => {
+        e.preventDefault();
         e.stopPropagation();
         showContextMenu(e, 'message', log.message || '');
     });
@@ -608,12 +609,14 @@ function createJSONElement(obj, indent = 0) {
         line.className = 'json-line filterable';
         line.style.paddingLeft = `${(indent + 1) * 16}px`;
 
-        // Make the whole line clickable for filtering
+        // Right-click handler for filtering by field value
         const displayValue = value === null ? 'null' :
             typeof value === 'object' ? JSON.stringify(value) : String(value);
-        line.addEventListener('click', (e) => {
+        const fileInfo = parseFilePath(typeof value === 'string' ? value : null);
+        line.addEventListener('contextmenu', (e) => {
+            e.preventDefault();
             e.stopPropagation();
-            showContextMenu(e, key, displayValue);
+            showContextMenu(e, key, displayValue, fileInfo || null);
         });
 
         // Key
@@ -692,7 +695,7 @@ function createValueElement(value) {
         if (fileInfo) {
             span.className = 'json-string json-file-link';
             span.textContent = `"${value}"`;
-            span.title = 'Click to open file (use right-click for filter menu)';
+            span.title = 'Click to open file';
             span.addEventListener('click', (e) => {
                 e.stopPropagation();
                 vscode.postMessage({
@@ -1130,11 +1133,9 @@ function updateNoResultsState() {
 // CONTEXT MENU FUNCTIONS
 // ============================================
 
-// Show context menu on click
-function showContextMenu(e, field, value) {
-    e.stopPropagation();
-
-    contextMenuTarget = { field, value: String(value) };
+// Show context menu on right-click
+function showContextMenu(e, field, value, fileInfo) {
+    contextMenuTarget = { field, value: String(value), fileInfo: fileInfo || null };
 
     const menu = document.getElementById('contextMenu');
     menu.classList.remove('hidden');
@@ -1148,6 +1149,19 @@ function showContextMenu(e, field, value) {
 
     includeItem.innerHTML = `<span class="menu-icon">+</span> Include ${escapeHtml(field)} = "${escapeHtml(truncatedValue)}"`;
     excludeItem.innerHTML = `<span class="menu-icon">-</span> Exclude ${escapeHtml(field)} = "${escapeHtml(truncatedValue)}"`;
+
+    // Show/hide "Open file" menu item based on file info
+    const openFileItem = document.getElementById('contextMenuOpenFile');
+    const fileSeparator = document.getElementById('contextMenuFileSeparator');
+    if (openFileItem && fileSeparator) {
+        if (contextMenuTarget.fileInfo) {
+            openFileItem.classList.remove('hidden');
+            fileSeparator.classList.remove('hidden');
+        } else {
+            openFileItem.classList.add('hidden');
+            fileSeparator.classList.add('hidden');
+        }
+    }
 
     // Position menu near click, but keep on screen
     const menuRect = menu.getBoundingClientRect();
@@ -1201,6 +1215,15 @@ function handleContextMenuAction(action) {
         case 'copy':
             navigator.clipboard.writeText(value);
             break;
+        case 'open_file':
+            if (contextMenuTarget.fileInfo) {
+                vscode.postMessage({
+                    type: 'openFile',
+                    filePath: contextMenuTarget.fileInfo.filePath,
+                    line: contextMenuTarget.fileInfo.line
+                });
+            }
+            break;
     }
 
     hideContextMenu();
@@ -1208,8 +1231,9 @@ function handleContextMenuAction(action) {
 
 // Initialize context menu handlers
 function initContextMenu() {
-    // Hide menu on click outside
+    // Hide menu on click or right-click outside
     document.addEventListener('click', hideContextMenu);
+    document.addEventListener('contextmenu', hideContextMenu);
 
     // Handle Escape key
     document.addEventListener('keydown', (e) => {


### PR DESCRIPTION
## Summary
- Left-click on log entries now expands/collapses instead of showing filter menu
- Filter actions (include/exclude/copy) moved to right-click context menu
- Right-clicking file path fields shows "Open file" option alongside filter actions
- Reduced vertical spacing between log entries for a more compact view

## Test plan
- [ ] Left-click on a log message expands/collapses the entry
- [ ] Right-click on a log message shows include/exclude/copy menu
- [ ] Right-click on a JSON field line shows filter menu
- [ ] Left-click on a file path opens the file
- [ ] Right-click on a file path line shows filter menu + "Open file" option
- [ ] Right-click elsewhere dismisses an open menu
- [ ] Log entries have reduced spacing between lines
- [ ] `npm test` passes