### PR TITLE
feat: Add lazy collapsible JSON feature

### DIFF
--- a/src/docs/lazyCollapsibleJson.md
+++ b/src/docs/lazyCollapsibleJson.md
@@ -1,0 +1,127 @@
+## Lazy collapsible JSON (objects / arrays)
+
+### Purpose
+
+Structured log fields (`log.otherFields`) can be large nested objects or arrays. The viewer renders **only one level at a time**: collapsed nodes show a short summary (`{ … }` / `[ … ]` plus counts). **Expanding** builds the immediate children in the DOM; **collapsing** removes those nodes again. That keeps work and DOM size proportional to what the user has opened, not to the full tree depth.
+
+### Where state lives
+
+| State                      | Location                                                                                                   | Role                                                                                                         |
+| -------------------------- | ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| **Expanded paths per log** | `expandedJsonPathsByLog` — a **`WeakMap`** keyed by the **same `ParsedLog` object** used in `session.logs` | Value: `Set<string>` of JSON paths (e.g. `user`, `user.address`, `items[0]`) that are currently **expanded** |
+| **Transient UI**           | DOM under each `.json-lazy-children` container                                                             | Only exists while the node is expanded; removed on collapse                                                  |
+| **Context menu**           | `contextMenuTarget` (separate variable)                                                                    | Holds `{ field, value, fileInfo }` for the **last right‑click**; not tied to lazy expansion                  |
+
+The **WeakMap** is intentional: when a log row is dropped from memory (clear session, eviction, GC), expansion bookkeeping can disappear with it—no leak of per-log state.
+
+### Path strings
+
+Paths identify a value **from the root of `otherFields`**. Segments use `.` for safe identifiers and `[index]` / `["quoted key"]` when needed (`appendJsonPath`, `parsePathSegments`, `getValueAtOtherFieldsPath`).
+
+### High-level architecture
+
+```mermaid
+flowchart TB
+  subgraph data [Data layer]
+    logObj[ParsedLog object in session.logs]
+    otherFields[log.otherFields]
+    weakMap[expandedJsonPathsByLog WeakMap]
+    pathSet["Set of expanded path strings"]
+    logObj --> otherFields
+    logObj -.->|key| weakMap
+    weakMap --> pathSet
+  end
+
+  subgraph dom [DOM layer]
+    createLog[createLogElement]
+    createJSON[createJSONElement]
+    createVal[createValueElement]
+    lazyRoot[buildLazyValueRoot]
+    appendCh[appendImmediateChildren]
+    clearCh[clearLazyChildren]
+    createLog --> createJSON --> createVal
+    createVal -->|object or array with ctx| lazyRoot
+    lazyRoot --> appendCh
+    lazyRoot --> clearCh
+  end
+
+  logObj --> createLog
+```
+
+### Expand / collapse flow (lazy node)
+
+```mermaid
+flowchart TD
+  start[User sees collapsed summary]
+  clickExpand[User clicks toggle]
+  append[appendImmediateChildren: one DOM level]
+  markAdd["markJsonPathExpanded: add ctx.path to WeakMap Set"]
+  expanded[Children visible in DOM]
+
+  clickCollapse[User clicks toggle again]
+  clear[clearLazyChildren: remove all child nodes]
+  markDel["markJsonPathCollapsed: delete ctx.path from Set"]
+  collapsed[Summary visible again]
+
+  start --> clickExpand --> append --> markAdd --> expanded
+  expanded --> clickCollapse --> clear --> markDel --> collapsed
+```
+
+- **Expand**: fills the children container once for that level, sets `aria-expanded`, shows the block, **`Set.add(path)`**.
+- **Collapse**: empties the children container (next expand rebuilds that level), hides the block, **`Set.delete(path)`** for **that node only**. Deeper paths can remain in the `Set`; when the parent is expanded again, nested nodes whose paths are still in the `Set` can auto-expand on rebuild.
+
+### After a full DOM rebuild (same log object)
+
+`renderCurrentSessionLogs` / `rerenderAllLogs` replace the log list DOM but keep **`session.logs` references**. On `buildLazyValueRoot`, if `isJsonPathExpanded(logRef, path)` is true, **`expand()`** runs immediately so the tree matches the **WeakMap** again.
+
+```mermaid
+sequenceDiagram
+  participant User
+  participant DOM
+  participant WeakMap as expandedJsonPathsByLog
+
+  User->>DOM: expand node at path P
+  DOM->>WeakMap: add P to Set for this log
+
+  Note over DOM: e.g. settings change triggers rerenderAllLogs
+
+  DOM->>DOM: destroy and recreate log DOM
+  DOM->>WeakMap: read Set for same log object
+  WeakMap-->>DOM: P still present
+  DOM->>DOM: buildLazyValueRoot calls expand for P
+```
+
+### Context menu vs lazy expansion
+
+These are **orthogonal**:
+
+1. **`attachContextMenuHandler(element, field, value, fileInfo)`** registers `contextmenu` → `showContextMenu`, which sets **`contextMenuTarget`** and positions the menu. It does **not** read or write `expandedJsonPathsByLog`.
+
+2. **Choosing Include/Exclude/Copy** in the menu uses `contextMenuTarget` and then **`hideContextMenu`**`. That only clears the menu target; it does **not** collapse lazy JSON nodes.
+
+```mermaid
+flowchart LR
+  subgraph lazy [Lazy JSON state]
+    WM[WeakMap path Set]
+    DOM[DOM children under node]
+  end
+
+  subgraph ctxMenu [Context menu state]
+    tgt[contextMenuTarget]
+    menu[Visible menu DOM]
+  end
+
+  rightClick[contextmenu on row] --> tgt
+  rightClick --> menu
+  action[Menu action or click outside] --> hide[hideContextMenu clears tgt]
+  hide -.->|does not touch| WM
+  hide -.->|does not touch| DOM
+```
+
+**Nested lazy rows** use `attachContextMenuHandler(row, childPath, displayValue, fileInfo)` so filters can use **dotted/bracket paths** under `otherFields` (`matchFilter` / `getFieldValue` resolve via `getValueAtOtherFieldsPath`).
+
+### When expansion state is lost
+
+- **Different log object** (new parse, new array slot in `session.logs`): new WeakMap entry—no remembered paths.
+- **Log removed from session / cleared**: reference gone; WeakMap entry is eligible for GC.
+- **Collapse**: only that path is removed from the `Set`; children disappear from DOM; **nested paths may remain** in the `Set` until explicitly collapsed or the log is GC’d.

--- a/src/docs/lazyCollapsibleJson.md
+++ b/src/docs/lazyCollapsibleJson.md
@@ -74,6 +74,8 @@ flowchart TD
 
 `renderCurrentSessionLogs` / `rerenderAllLogs` replace the log list DOM but keep **`session.logs` references**. On `buildLazyValueRoot`, if `isJsonPathExpanded(logRef, path)` is true, **`expand()`** runs immediately so the tree matches the **WeakMap** again.
 
+This applies only to rebuilds that keep the same `ParsedLog` objects. Field-alias setting changes use `replaceSessionLogs`, which re-parses each raw line and replaces `session.logs` with new `ParsedLog` objects, so the WeakMap keys no longer match and expansion state is reset.
+
 ```mermaid
 sequenceDiagram
   participant User
@@ -83,7 +85,7 @@ sequenceDiagram
   User->>DOM: expand node at path P
   DOM->>WeakMap: add P to Set for this log
 
-  Note over DOM: e.g. settings change triggers rerenderAllLogs
+  Note over DOM: e.g. display setting change triggers rerenderAllLogs
 
   DOM->>DOM: destroy and recreate log DOM
   DOM->>WeakMap: read Set for same log object
@@ -123,5 +125,6 @@ flowchart LR
 ### When expansion state is lost
 
 - **Different log object** (new parse, new array slot in `session.logs`): new WeakMap entry—no remembered paths.
+- **Field-alias settings changed**: `replaceSessionLogs` re-parses logs into new `ParsedLog` objects, so previous WeakMap entries do not apply.
 - **Log removed from session / cleared**: reference gone; WeakMap entry is eligible for GC.
 - **Collapse**: only that path is removed from the `Set`; children disappear from DOM; **nested paths may remain** in the `Set` until explicitly collapsed or the log is GC’d.

--- a/src/webview/pathUtils.js
+++ b/src/webview/pathUtils.js
@@ -1,0 +1,145 @@
+"use strict";
+
+
+
+(function (root, factory) {
+  const utils = factory();
+  root.SlogViewerPathUtils = utils;
+
+  if (typeof module === "object" && module.exports) {
+    module.exports = utils;
+  }
+})(typeof globalThis !== "undefined" ? globalThis : this, function () {
+  const VALID_IDENTIFIER = /^[a-zA-Z_$][\w$]*$/;
+  const HEX_4 = /^[0-9a-fA-F]{4}$/;
+
+  /**
+   * Decode JSON-style escape sequences inside a quoted path segment.
+   *
+   * @param {string} segment
+   * @returns {string}
+   * @example decodeJsonPathEscapes(`hello\nworld\t\"test\"`)
+   */
+  function decodeJsonPathEscapes(segment) {
+    const escaped = String.raw`"${segment}"`;
+
+    return JSON.parse(escaped);
+  }
+
+  /**
+   * Append parent path to the segment key carefully
+   *
+   * @param {string} parentPath
+   * @param {string|number} segment
+   *
+   * @returns {string}
+   *
+   * @example appendJsonPath('user', 'salam\"hello') // 'user["salam\"hello"]
+   */
+  function appendJsonPath(parentPath, segment) {
+    const VALID_IDENTIFIER = /^[a-zA-Z_$][\w$]*$/;
+
+    // if it's not number or a valid identifier in js use .
+    if (typeof segment !== "number" && VALID_IDENTIFIER.test(segment))
+      return `${parentPath && parentPath + "."}${segment}`;
+
+    return `${parentPath}[${JSON.stringify(segment)}]`;
+  }
+
+  /**
+   * Parse a field path like `user.items[0].name` into segments for walking `otherFields`.
+   *
+   * @param {string} path
+   * @returns {(string|number)[]}
+   */
+  function parsePathSegments(path) {
+    const segments = [];
+    let i = 0;
+    while (i < path.length) {
+      if (path[i] === ".") {
+        i++;
+        continue;
+      }
+      if (path[i] === "[") {
+        i++;
+        if (path[i] === '"' || path[i] === "'") {
+          const q = path[i];
+          i++;
+          let raw = "";
+          while (i < path.length) {
+            if (path[i] === "\\" && i + 1 < path.length) {
+              raw += path[i];
+              raw += path[i + 1];
+              i += 2;
+              continue;
+            }
+            if (path[i] === q) {
+              i++;
+              break;
+            }
+            raw += path[i];
+            i++;
+          }
+          segments.push(decodeJsonPathEscapes(raw));
+          if (path[i] === "]") {
+            i++;
+          }
+        } else {
+          let n = "";
+          while (i < path.length && path[i] >= "0" && path[i] <= "9") {
+            n += path[i];
+            i++;
+          }
+          segments.push(Number(n));
+          if (path[i] === "]") {
+            i++;
+          }
+        }
+        continue;
+      }
+      let ident = "";
+      while (i < path.length && /[a-zA-Z0-9_$]/.test(path[i])) {
+        ident += path[i];
+        i++;
+      }
+      if (ident) {
+        segments.push(ident);
+      } else {
+        break;
+      }
+    }
+    return segments;
+  }
+
+  /**
+   * Read a nested value from `otherFields` using dot / bracket path notation.
+   *
+   * @param {Record<string, unknown>|undefined} otherFields
+   * @param {string} path
+   * @returns {unknown}
+   */
+  function getValueAtOtherFieldsPath(otherFields, path) {
+    if (!path || !otherFields || typeof otherFields !== "object") {
+      return undefined;
+    }
+    const parts = parsePathSegments(path);
+    if (parts.length === 0) {
+      return undefined;
+    }
+    let cur = otherFields;
+    for (const p of parts) {
+      if (cur == null || typeof cur !== "object") {
+        return undefined;
+      }
+      cur = cur[p];
+    }
+    return cur;
+  }
+
+  return {
+    decodeJsonPathEscapes,
+    appendJsonPath,
+    parsePathSegments,
+    getValueAtOtherFieldsPath,
+  };
+});

--- a/src/webview/pathUtils.test.ts
+++ b/src/webview/pathUtils.test.ts
@@ -1,0 +1,111 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+const {
+  decodeJsonPathEscapes,
+  appendJsonPath,
+  parsePathSegments,
+  getValueAtOtherFieldsPath,
+}: {
+  decodeJsonPathEscapes: (raw: string) => string;
+  appendJsonPath: (parentPath: string, segment: string | number) => string;
+  parsePathSegments: (path: string) => Array<string | number>;
+  getValueAtOtherFieldsPath: (
+    otherFields: Record<string, unknown> | undefined,
+    path: string,
+  ) => unknown;
+} = require("./pathUtils.js");
+
+describe("webview pathUtils", () => {
+  describe("decodeJsonPathEscapes", () => {
+    it("should decode JSON control escapes", () => {
+      expect(decodeJsonPathEscapes("line\\nbreak")).toBe("line\nbreak");
+      expect(decodeJsonPathEscapes("tab\\tkey")).toBe("tab\tkey");
+      expect(decodeJsonPathEscapes("carriage\\rreturn")).toBe("carriage\rreturn");
+      expect(decodeJsonPathEscapes("back\\bspace")).toBe("back\bspace");
+      expect(decodeJsonPathEscapes("form\\ffeed")).toBe("form\ffeed");
+    });
+
+    it("should decode JSON quote, slash, backslash, and unicode escapes", () => {
+      expect(decodeJsonPathEscapes('quoted\\"key')).toBe('quoted"key');
+      expect(decodeJsonPathEscapes("path\\\\to\\\\file")).toBe("path\\to\\file");
+      expect(decodeJsonPathEscapes("a\\/b")).toBe("a/b");
+      expect(decodeJsonPathEscapes("snowman \\u2603")).toBe("snowman \u2603");
+    });
+  });
+
+  describe("appendJsonPath and parsePathSegments", () => {
+    it("should round-trip keys with JSON escape sequences", () => {
+      const keys = [
+        "line\nbreak",
+        "tab\tkey",
+        "path\\to\\file",
+        'quoted"key',
+        "snowman \u2603",
+        "key.with.dot and space",
+      ];
+
+      keys.forEach(key => {
+        const path = appendJsonPath("", key);
+        expect(parsePathSegments(path)).toEqual([key]);
+      });
+    });
+
+    it("should preserve existing simple path behavior", () => {
+      expect(parsePathSegments("user.name")).toEqual(["user", "name"]);
+      expect(parsePathSegments("items[0].id")).toEqual(["items", 0, "id"]);
+      expect(parsePathSegments('["key.with.dot"]')).toEqual(["key.with.dot"]);
+    });
+
+    it("should parse quoted path segments with unicode escapes", () => {
+      expect(parsePathSegments('["snowman \\u2603"]')).toEqual(["snowman \u2603"]);
+    });
+
+    it("should round-trip nested object and array paths", () => {
+      const parentPath = appendJsonPath("", "items");
+      const arrayPath = appendJsonPath(parentPath, 0);
+      const childPath = appendJsonPath(arrayPath, 'quoted"key');
+
+      expect(childPath).toBe('items[0]["quoted\\"key"]');
+      expect(parsePathSegments(childPath)).toEqual(["items", 0, 'quoted"key']);
+    });
+  });
+
+  describe("getValueAtOtherFieldsPath", () => {
+    it("should read root fields with escaped path keys", () => {
+      const otherFields = {
+        "line\nbreak": "newline value",
+      };
+
+      expect(getValueAtOtherFieldsPath(otherFields, '["line\\nbreak"]')).toBe("newline value");
+    });
+
+    it("should read nested fields with escaped path keys", () => {
+      const otherFields = {
+        parent: {
+          "tab\tkey": "tab value",
+        },
+        items: [
+          {
+            'quoted"key': "quote value",
+          },
+        ],
+      };
+
+      expect(getValueAtOtherFieldsPath(otherFields, 'parent["tab\\tkey"]')).toBe("tab value");
+      expect(getValueAtOtherFieldsPath(otherFields, 'items[0]["quoted\\"key"]')).toBe(
+        "quote value",
+      );
+    });
+
+    it("should read existing simple nested paths", () => {
+      const otherFields = {
+        user: { name: "Amir" },
+        items: [{ id: 1 }],
+        "key.with.dot": "dot value",
+      };
+
+      expect(getValueAtOtherFieldsPath(otherFields, "user.name")).toBe("Amir");
+      expect(getValueAtOtherFieldsPath(otherFields, "items[0].id")).toBe(1);
+      expect(getValueAtOtherFieldsPath(otherFields, '["key.with.dot"]')).toBe("dot value");
+    });
+  });
+});

--- a/src/webview/styles.css
+++ b/src/webview/styles.css
@@ -587,6 +587,7 @@ body {
 .json-line {
     padding: 2px 0;
     white-space: pre;
+    overflow-x: auto;
 }
 
 .json-key {
@@ -623,6 +624,60 @@ body {
 .json-file-link:hover {
     color: var(--vscode-textLink-foreground, #3794ff);
     text-decoration-style: solid;
+}
+
+/* Lazy collapsible object / array values */
+.json-lazy-value {
+    display: inline-block;
+    vertical-align: top;
+    max-width: 100%;
+}
+
+.json-lazy-header {
+    white-space: pre;
+}
+
+.json-lazy-toggle {
+    display: inline-block;
+    font-size: 12px;
+    font-family: inherit;
+    color: inherit;
+    background: transparent;
+    border: none;
+    padding: 0 4px 0 0;
+    margin: 0;
+    cursor: pointer;
+    vertical-align: middle;
+    line-height: 1;
+}
+
+.json-lazy-toggle:focus-visible {
+    outline: 1px solid var(--focus-border, var(--vscode-focusBorder, #007fd4));
+    outline-offset: 1px;
+}
+
+.json-lazy-meta {
+    opacity: 0.75;
+    font-size: 11px;
+}
+
+.json-lazy-children {
+    padding-left: 14px;
+    border-left: 1px solid var(--border-color);
+    margin: 2px 0 0 6px;
+}
+
+.json-lazy-children.hidden {
+    display: none;
+}
+
+.json-lazy-row {
+    padding: 1px 0;
+    white-space: pre;
+}
+
+.json-lazy-close-row {
+    padding-top: 0;
 }
 
 /* Original JSON (collapsed by default) */

--- a/src/webview/webview.js
+++ b/src/webview/webview.js
@@ -28,6 +28,9 @@ let filterIdCounter = 0;  // For generating unique filter IDs
 // { field, value, fileInfo? } — fileInfo is only set when right-clicking JSON lines containing file paths
 let contextMenuTarget = null;
 
+/** @type {WeakMap<object, Set<string>>} Tracks expanded JSON paths per log object across DOM rebuilds. */
+const expandedJsonPathsByLog = new WeakMap();
+
 // Filter operators
 const FILTER_OPERATORS = {
     contains: (fieldValue, filterValue) =>
@@ -540,7 +543,7 @@ function createLogElement(log, index) {
     body.className = config.collapseJSON ? 'log-body collapsed' : 'log-body';
 
     if (log.otherFields && Object.keys(log.otherFields).length > 0) {
-        body.appendChild(createJSONElement(log.otherFields));
+        body.appendChild(createJSONElement(log.otherFields, 0, log));
     }
 
     entry.appendChild(body);
@@ -570,8 +573,14 @@ function createLogElement(log, index) {
     return entry;
 }
 
-// Create JSON element with syntax highlighting
-function createJSONElement(obj, indent = 0) {
+/**
+ * Create JSON element with syntax highlighting.
+ *
+ * @param {Record<string, unknown>} obj
+ * @param {number} [indent]
+ * @param {object | null} [logRef] Parsed log for lazy nested value expansion state
+ */
+function createJSONElement(obj, indent = 0, logRef = null) {
     const container = document.createElement('div');
 
     if (Object.keys(obj).length === 0) {
@@ -624,7 +633,7 @@ function createJSONElement(obj, indent = 0) {
         line.appendChild(colonSpan);
 
         // Value — pass fileInfo to avoid re-parsing
-        const valueSpan = createValueElement(value, fileInfo);
+        const valueSpan = createValueElement(value, fileInfo, logRef ? { logRef, path: key } : null);
         line.appendChild(valueSpan);
 
         // Comma
@@ -668,9 +677,363 @@ function parseFilePath(value) {
     return null;
 }
 
-// Create value element with proper styling
-// fileInfo is optional — passed from createJSONElement to avoid redundant parseFilePath calls
-function createValueElement(value, fileInfo) {
+// ============================================
+// LAZY COLLAPSIBLE JSON (objects / arrays)
+// ============================================
+
+/**
+ * 
+ * @param {unknown} value
+ * @returns {value is Record<string, unknown>}
+ */
+function isPlainObjectLike(value) {
+    return value !== null && typeof value === 'object' && !Array.isArray(value) &&
+        Object.prototype.toString.call(value) === '[object Object]';
+}
+
+/**
+ * @param {string} parentPath Path from root of `otherFields`
+ * @param {string|number} segment Property name or array index
+ * @returns {string}
+ */
+function appendJsonPath(parentPath, segment) {
+    if (typeof segment === 'number') {
+        return `${parentPath}[${segment}]`;
+    }
+    if (parentPath === '') {
+        if (/^[a-zA-Z_$][\w$]*$/.test(segment)) {
+            return segment;
+        }
+        return `[${JSON.stringify(segment)}]`;
+    }
+    if (/^[a-zA-Z_$][\w$]*$/.test(segment)) {
+        return `${parentPath}.${segment}`;
+    }
+    return `${parentPath}[${JSON.stringify(segment)}]`;
+}
+
+/**
+ * @param {object} logRef
+ * @returns {Set<string>}
+ */
+function getOrCreateExpandedPathSet(logRef) {
+    let set = expandedJsonPathsByLog.get(logRef);
+    if (!set) {
+        set = new Set();
+        expandedJsonPathsByLog.set(logRef, set);
+    }
+    return set;
+}
+
+/** @param {object} logRef @param {string} path */
+function markJsonPathExpanded(logRef, path) {
+    getOrCreateExpandedPathSet(logRef).add(path);
+}
+
+/** @param {object} logRef @param {string} path */
+function markJsonPathCollapsed(logRef, path) {
+    const set = expandedJsonPathsByLog.get(logRef);
+    if (set) {
+        set.delete(path);
+    }
+}
+
+/** @param {object} logRef @param {string} path */
+function isJsonPathExpanded(logRef, path) {
+    const set = expandedJsonPathsByLog.get(logRef);
+    return !!set && set.has(path);
+}
+
+/**
+ * Remove all child nodes from a lazy children container (collapse).
+ *
+ * @param {HTMLElement} childrenEl
+ */
+function clearLazyChildren(childrenEl) {
+    while (childrenEl.firstChild) {
+        childrenEl.removeChild(childrenEl.firstChild);
+    }
+}
+
+/**
+ * Append one level of rows under a collapsible node; closing bracket on its own row.
+ *
+ * @param {HTMLElement} childrenEl
+ * @param {object|unknown[]} value
+ * @param {{ logRef: object, path: string }} ctx
+ * @param {string} closeCh `}` or `]`
+ */
+function appendImmediateChildren(childrenEl, value, ctx, closeCh) {
+    if (Array.isArray(value)) {
+        for (let index = 0; index < value.length; index++) {
+            const item = value[index];
+            const row = document.createElement('div');
+            row.className = 'json-lazy-row filterable';
+            const childPath = appendJsonPath(ctx.path, index);
+            const displayValue = item === null ? 'null' :
+                typeof item === 'object' ? JSON.stringify(item) : String(item);
+            const fileInfo = typeof item === 'string' ? parseFilePath(item) : null;
+            attachContextMenuHandler(row, childPath, displayValue, fileInfo);
+
+            const indexSpan = document.createElement('span');
+            indexSpan.className = 'json-key';
+            indexSpan.textContent = String(index);
+            row.appendChild(indexSpan);
+
+            const colonSpan = document.createElement('span');
+            colonSpan.className = 'json-punctuation';
+            colonSpan.textContent = ': ';
+            row.appendChild(colonSpan);
+
+            row.appendChild(createValueElement(item, fileInfo, { logRef: ctx.logRef, path: childPath }));
+
+            if (index < value.length - 1) {
+                const commaSpan = document.createElement('span');
+                commaSpan.className = 'json-punctuation';
+                commaSpan.textContent = ',';
+                row.appendChild(commaSpan);
+            }
+
+            childrenEl.appendChild(row);
+        }
+    } else {
+        const entries = Object.entries(value);
+        entries.forEach(([key, val], index) => {
+            const row = document.createElement('div');
+            row.className = 'json-lazy-row filterable';
+            const childPath = appendJsonPath(ctx.path, key);
+            const displayValue = val === null ? 'null' :
+                typeof val === 'object' ? JSON.stringify(val) : String(val);
+            const fileInfo = typeof val === 'string' ? parseFilePath(val) : null;
+            attachContextMenuHandler(row, childPath, displayValue, fileInfo);
+
+            const keySpan = document.createElement('span');
+            keySpan.className = 'json-key';
+            keySpan.textContent = `"${key}"`;
+            row.appendChild(keySpan);
+
+            const colonSpan = document.createElement('span');
+            colonSpan.className = 'json-punctuation';
+            colonSpan.textContent = ': ';
+            row.appendChild(colonSpan);
+
+            row.appendChild(createValueElement(val, fileInfo, { logRef: ctx.logRef, path: childPath }));
+
+            if (index < entries.length - 1) {
+                const commaSpan = document.createElement('span');
+                commaSpan.className = 'json-punctuation';
+                commaSpan.textContent = ',';
+                row.appendChild(commaSpan);
+            }
+
+            childrenEl.appendChild(row);
+        });
+    }
+
+    const closeLine = document.createElement('div');
+    closeLine.className = 'json-lazy-row json-lazy-close-row';
+    const closePunct = document.createElement('span');
+    closePunct.className = 'json-punctuation';
+    closePunct.textContent = closeCh;
+    closeLine.appendChild(closePunct);
+    childrenEl.appendChild(closeLine);
+}
+
+/**
+ * Build a collapsible object or array viewer (one DOM level at a time).
+ *
+ * @param {object|unknown[]} value
+ * @param {{ logRef: object, path: string }} ctx
+ * @returns {HTMLElement}
+ */
+function buildLazyValueRoot(value, ctx) {
+    const root = document.createElement('div');
+    root.className = 'json-lazy-value';
+
+    const isArray = Array.isArray(value);
+    const openCh = isArray ? '[' : '{';
+    const closeCh = isArray ? ']' : '}';
+
+    const header = document.createElement('span');
+    header.className = 'json-lazy-header';
+
+    const toggle = document.createElement('button');
+    toggle.type = 'button';
+    toggle.className = 'json-lazy-toggle collapse-icon collapsed';
+    toggle.textContent = '▼';
+    toggle.setAttribute('aria-expanded', 'false');
+    toggle.title = 'Expand or collapse';
+
+    const openPunct = document.createElement('span');
+    openPunct.className = 'json-punctuation';
+    openPunct.textContent = openCh;
+
+    const suffix = document.createElement('span');
+    suffix.className = 'json-lazy-collapsed-suffix';
+
+    const ellipsis = document.createElement('span');
+    ellipsis.className = 'json-lazy-ellipsis';
+    ellipsis.textContent = ' … ';
+
+    const closePunctSuffix = document.createElement('span');
+    closePunctSuffix.className = 'json-punctuation';
+    closePunctSuffix.textContent = closeCh;
+
+    const meta = document.createElement('span');
+    meta.className = 'json-lazy-meta';
+    const count = isArray ? value.length : Object.keys(value).length;
+    meta.textContent = isArray
+        ? ` ${count} item${count === 1 ? '' : 's'}`
+        : ` ${count} key${count === 1 ? '' : 's'}`;
+
+    suffix.appendChild(ellipsis);
+    suffix.appendChild(closePunctSuffix);
+    suffix.appendChild(meta);
+
+    const childrenEl = document.createElement('div');
+    childrenEl.className = 'json-lazy-children hidden';
+
+    header.appendChild(toggle);
+    header.appendChild(openPunct);
+    header.appendChild(suffix);
+
+    root.appendChild(header);
+    root.appendChild(childrenEl);
+
+    const expand = () => {
+        clearLazyChildren(childrenEl);
+        appendImmediateChildren(childrenEl, value, ctx, closeCh);
+        suffix.style.display = 'none';
+        childrenEl.classList.remove('hidden');
+        toggle.classList.remove('collapsed');
+        toggle.setAttribute('aria-expanded', 'true');
+        markJsonPathExpanded(ctx.logRef, ctx.path);
+    };
+
+    const collapse = () => {
+        clearLazyChildren(childrenEl);
+        suffix.style.display = '';
+        childrenEl.classList.add('hidden');
+        toggle.classList.add('collapsed');
+        toggle.setAttribute('aria-expanded', 'false');
+        markJsonPathCollapsed(ctx.logRef, ctx.path);
+    };
+
+    toggle.addEventListener('click', (e) => {
+        e.stopPropagation();
+        if (toggle.getAttribute('aria-expanded') === 'true') {
+            collapse();
+        } else {
+            expand();
+        }
+    });
+
+    if (isJsonPathExpanded(ctx.logRef, ctx.path)) {
+        expand();
+    }
+
+    return root;
+}
+
+/**
+ * Parse a field path like `user.items[0].name` into segments for walking `otherFields`.
+ *
+ * @param {string} path
+ * @returns {(string|number)[]}
+ */
+function parsePathSegments(path) {
+    const segments = [];
+    let i = 0;
+    while (i < path.length) {
+        if (path[i] === '.') {
+            i++;
+            continue;
+        }
+        if (path[i] === '[') {
+            i++;
+            if (path[i] === '"' || path[i] === "'") {
+                const q = path[i];
+                i++;
+                let s = '';
+                while (i < path.length) {
+                    if (path[i] === '\\' && i + 1 < path.length) {
+                        i++;
+                        s += path[i];
+                        i++;
+                        continue;
+                    }
+                    if (path[i] === q) {
+                        i++;
+                        break;
+                    }
+                    s += path[i];
+                    i++;
+                }
+                segments.push(s);
+                if (path[i] === ']') {
+                    i++;
+                }
+            } else {
+                let n = '';
+                while (i < path.length && path[i] >= '0' && path[i] <= '9') {
+                    n += path[i];
+                    i++;
+                }
+                segments.push(Number(n));
+                if (path[i] === ']') {
+                    i++;
+                }
+            }
+            continue;
+        }
+        let ident = '';
+        while (i < path.length && /[a-zA-Z0-9_$]/.test(path[i])) {
+            ident += path[i];
+            i++;
+        }
+        if (ident) {
+            segments.push(ident);
+        } else {
+            break;
+        }
+    }
+    return segments;
+}
+
+/**
+ * Read a nested value from `otherFields` using dot / bracket path notation.
+ *
+ * @param {Record<string, unknown>|undefined} otherFields
+ * @param {string} path
+ * @returns {unknown}
+ */
+function getValueAtOtherFieldsPath(otherFields, path) {
+    if (!path || !otherFields || typeof otherFields !== 'object') {
+        return undefined;
+    }
+    const parts = parsePathSegments(path);
+    if (parts.length === 0) {
+        return undefined;
+    }
+    let cur = otherFields;
+    for (const p of parts) {
+        if (cur == null || typeof cur !== 'object') {
+            return undefined;
+        }
+        cur = cur[p];
+    }
+    return cur;
+}
+
+/**
+ * Create a styled DOM node for a JSON value (primitives, file links, or lazy object/array).
+ *
+ * @param {unknown} value
+ * @param {unknown} [fileInfo] Pre-parsed file link for strings (avoids duplicate `parseFilePath`)
+ * @param {{ logRef: object, path: string } | null} [ctx] When set, plain objects and non-empty arrays render lazily
+ * @returns {HTMLElement}
+ */
+function createValueElement(value, fileInfo, ctx) {
     const span = document.createElement('span');
 
     if (value === null) {
@@ -702,11 +1065,28 @@ function createValueElement(value, fileInfo) {
             span.textContent = `"${value}"`;
         }
     } else if (Array.isArray(value)) {
-        span.className = 'json-string';
-        span.textContent = JSON.stringify(value);
+        if (value.length === 0) {
+            span.className = 'json-punctuation';
+            span.textContent = '[]';
+        } else if (ctx && ctx.logRef) {
+            return buildLazyValueRoot(value, ctx);
+        } else {
+            span.className = 'json-string';
+            span.textContent = JSON.stringify(value);
+        }
     } else if (typeof value === 'object') {
-        span.className = 'json-string';
-        span.textContent = JSON.stringify(value);
+        if (!isPlainObjectLike(value)) {
+            span.className = 'json-string';
+            span.textContent = JSON.stringify(value);
+        } else if (Object.keys(value).length === 0) {
+            span.className = 'json-punctuation';
+            span.textContent = '{}';
+        } else if (ctx && ctx.logRef) {
+            return buildLazyValueRoot(value, ctx);
+        } else {
+            span.className = 'json-string';
+            span.textContent = JSON.stringify(value);
+        }
     } else {
         span.textContent = String(value);
     }
@@ -953,7 +1333,10 @@ function matchFilter(log, filter) {
     } else if (field === 'level') {
         fieldValue = log.level || '';
     } else {
-        fieldValue = log.otherFields?.[field];
+        fieldValue = getValueAtOtherFieldsPath(log.otherFields, field);
+        if (fieldValue === undefined) {
+            fieldValue = log.otherFields?.[field];
+        }
         if (fieldValue === undefined || fieldValue === null) return false;
     }
 
@@ -965,6 +1348,10 @@ function matchFilter(log, filter) {
 function getFieldValue(log, field) {
     if (field === 'message') return log.message || '';
     if (field === 'level') return log.level || '';
+    const nested = getValueAtOtherFieldsPath(log.otherFields, field);
+    if (nested !== undefined) {
+        return typeof nested === 'object' ? JSON.stringify(nested) : String(nested);
+    }
     return log.otherFields?.[field] ?? '';
 }
 

--- a/src/webview/webview.js
+++ b/src/webview/webview.js
@@ -32,6 +32,11 @@ let contextMenuTarget = null;
 /** @type {WeakMap<object, Set<string>>} Tracks expanded JSON paths per log object across DOM rebuilds. */
 const expandedJsonPathsByLog = new WeakMap();
 
+const {
+    appendJsonPath,
+    getValueAtOtherFieldsPath
+} = globalThis.SlogViewerPathUtils;
+
 // Filter operators
 const FILTER_OPERATORS = {
     contains: (fieldValue, filterValue) =>
@@ -776,27 +781,6 @@ function isPlainObjectLike(value) {
 }
 
 /**
- * @param {string} parentPath Path from root of `otherFields`
- * @param {string|number} segment Property name or array index
- * @returns {string}
- */
-function appendJsonPath(parentPath, segment) {
-    if (typeof segment === 'number') {
-        return `${parentPath}[${segment}]`;
-    }
-    if (parentPath === '') {
-        if (/^[a-zA-Z_$][\w$]*$/.test(segment)) {
-            return segment;
-        }
-        return `[${JSON.stringify(segment)}]`;
-    }
-    if (/^[a-zA-Z_$][\w$]*$/.test(segment)) {
-        return `${parentPath}.${segment}`;
-    }
-    return `${parentPath}[${JSON.stringify(segment)}]`;
-}
-
-/**
  * @param {object} logRef
  * @returns {Set<string>}
  */
@@ -1017,96 +1001,6 @@ function buildLazyValueRoot(value, ctx) {
     }
 
     return root;
-}
-
-/**
- * Parse a field path like `user.items[0].name` into segments for walking `otherFields`.
- *
- * @param {string} path
- * @returns {(string|number)[]}
- */
-function parsePathSegments(path) {
-    const segments = [];
-    let i = 0;
-    while (i < path.length) {
-        if (path[i] === '.') {
-            i++;
-            continue;
-        }
-        if (path[i] === '[') {
-            i++;
-            if (path[i] === '"' || path[i] === "'") {
-                const q = path[i];
-                i++;
-                let s = '';
-                while (i < path.length) {
-                    if (path[i] === '\\' && i + 1 < path.length) {
-                        i++;
-                        s += path[i];
-                        i++;
-                        continue;
-                    }
-                    if (path[i] === q) {
-                        i++;
-                        break;
-                    }
-                    s += path[i];
-                    i++;
-                }
-                segments.push(s);
-                if (path[i] === ']') {
-                    i++;
-                }
-            } else {
-                let n = '';
-                while (i < path.length && path[i] >= '0' && path[i] <= '9') {
-                    n += path[i];
-                    i++;
-                }
-                segments.push(Number(n));
-                if (path[i] === ']') {
-                    i++;
-                }
-            }
-            continue;
-        }
-        let ident = '';
-        while (i < path.length && /[a-zA-Z0-9_$]/.test(path[i])) {
-            ident += path[i];
-            i++;
-        }
-        if (ident) {
-            segments.push(ident);
-        } else {
-            break;
-        }
-    }
-    return segments;
-}
-
-/**
- * Read a nested value from `otherFields` using dot / bracket path notation.
- *
- * @param {Record<string, unknown>|undefined} otherFields
- * @param {string} path
- * @returns {unknown}
- */
-function getValueAtOtherFieldsPath(otherFields, path) {
-    if (!path || !otherFields || typeof otherFields !== 'object') {
-        return undefined;
-    }
-    const parts = parsePathSegments(path);
-    if (parts.length === 0) {
-        return undefined;
-    }
-    let cur = otherFields;
-    for (const p of parts) {
-        if (cur == null || typeof cur !== 'object') {
-            return undefined;
-        }
-        cur = cur[p];
-    }
-    return cur;
 }
 
 /**

--- a/src/webviewPanel.ts
+++ b/src/webviewPanel.ts
@@ -462,13 +462,21 @@ export class SlogViewerWebviewProvider implements vscode.WebviewViewProvider {
     const css = fs.readFileSync(cssPath, 'utf8');
 
     // Read JavaScript
+    const pathUtilsPath = path.join(
+      this.extensionUri.fsPath,
+      'dist',
+      'webview',
+      'pathUtils.js'
+    );
+    const pathUtilsJs = fs.readFileSync(pathUtilsPath, 'utf8');
+
     const jsPath = path.join(
       this.extensionUri.fsPath,
       'dist',
       'webview',
       'webview.js'
     );
-    const js = fs.readFileSync(jsPath, 'utf8');
+    const js = `${pathUtilsJs}\n${fs.readFileSync(jsPath, 'utf8')}`;
 
     // Generate nonce for security
     const nonce = this.getNonce();


### PR DESCRIPTION
- Introduced a new markdown document detailing the lazy collapsible JSON functionality for structured log fields.
- Implemented CSS styles for lazy collapsible object/array values, enhancing the visual representation of JSON data.
- Updated JavaScript to support lazy loading of JSON elements, allowing for efficient expansion and collapsing of nested structures.
- Added a WeakMap to track expanded JSON paths per log object, ensuring state persistence across DOM rebuilds.

Closes #18 