### PR TITLE
Truncate long log messages with a Show more toggle (#21)

### DIFF
--- a/package.json
+++ b/package.json
@@ -194,6 +194,12 @@
           "type": "boolean",
           "default": true,
           "description": "Automatically reveal the Slog Viewer panel when the first structured log is detected. When disabled, open the panel manually."
+        },
+        "slogViewer.messageMaxLength": {
+          "type": "number",
+          "default": 200,
+          "minimum": 0,
+          "description": "Maximum characters of a log message shown before truncation. Click \"Show more\" to reveal the full message. Set to 0 to disable truncation."
         }
       }
     }

--- a/src/messageTypes.ts
+++ b/src/messageTypes.ts
@@ -108,4 +108,5 @@ export interface WebviewConfig {
   showRawJSON: boolean;
   autoScroll: boolean;
   theme: 'light' | 'dark' | 'auto';
+  messageMaxLength: number;
 }

--- a/src/webview/styles.css
+++ b/src/webview/styles.css
@@ -568,7 +568,51 @@ body {
 
 .log-message {
     flex: 1;
+    /* Allow the flex child to shrink so a long unbroken string cannot
+       force horizontal overflow of the log row. */
+    min-width: 0;
     font-size: 13px;
+}
+
+/* When the message is truncated it holds a preview + toggle; lay them
+   out on one line with the toggle pinned to the end. */
+.log-message:has(> .log-message-toggle) {
+    display: flex;
+    align-items: baseline;
+    gap: 6px;
+}
+
+/* Truncated message preview (collapsed: single line with ellipsis) */
+.log-message-preview {
+    flex: 1;
+    min-width: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.log-message-preview.expanded {
+    white-space: pre-wrap;
+    overflow: visible;
+    word-break: break-word;
+}
+
+/* "Show more" / "Show less" toggle */
+.log-message-toggle {
+    flex-shrink: 0;
+    align-self: flex-start;
+    padding: 0;
+    border: none;
+    background: none;
+    font-size: 12px;
+    cursor: pointer;
+    color: var(--vscode-textLink-foreground, #3794ff);
+}
+
+.log-message-toggle:hover,
+.log-message-toggle:focus {
+    text-decoration: underline;
+    color: var(--vscode-textLink-activeForeground, var(--vscode-textLink-foreground, #3794ff));
 }
 
 /* Log body (JSON fields) */

--- a/src/webview/webview.js
+++ b/src/webview/webview.js
@@ -9,7 +9,8 @@ let config = {
     collapseJSON: true,
     showRawJSON: false,
     autoScroll: true,
-    theme: 'auto'
+    theme: 'auto',
+    messageMaxLength: 200
 };
 
 // Session management
@@ -473,6 +474,56 @@ function reindexLogEntries() {
     });
 }
 
+// Render the message text into a span, truncating long messages with a
+// "Show more"/"Show less" toggle. The context menu still receives the full
+// message, so copying is unaffected.
+function renderMessageContent(span, text) {
+    const fullText = String(text ?? '');
+    const max = config.messageMaxLength;
+
+    if (!max || max <= 0 || fullText.length <= max) {
+        span.textContent = fullText;
+        return;
+    }
+
+    // Collapsed preview keeps the message on a single line.
+    const collapsedText = fullText.slice(0, max).replace(/\s*\n\s*/g, ' ') + '…';
+
+    const preview = document.createElement('span');
+    preview.className = 'log-message-preview';
+    preview.textContent = collapsedText;
+
+    const toggle = document.createElement('button');
+    toggle.type = 'button';
+    toggle.className = 'log-message-toggle';
+    toggle.textContent = 'Show more';
+
+    let expanded = false;
+    toggle.addEventListener('click', (e) => {
+        // Don't trigger the header's JSON expand/collapse handler.
+        e.stopPropagation();
+        expanded = !expanded;
+        if (expanded) {
+            preview.textContent = fullText;
+            preview.classList.add('expanded');
+            toggle.textContent = 'Show less';
+            // Pause auto-scroll so new logs don't push the message away
+            // while the user reads it (mirrors the header expand behavior).
+            if (autoScrollActive) {
+                autoScrollActive = false;
+                updateAutoScrollButton();
+            }
+        } else {
+            preview.textContent = collapsedText;
+            preview.classList.remove('expanded');
+            toggle.textContent = 'Show more';
+        }
+    });
+
+    span.appendChild(preview);
+    span.appendChild(toggle);
+}
+
 // Create log element
 function createLogElement(log, index) {
     const entry = document.createElement('div');
@@ -505,7 +556,7 @@ function createLogElement(log, index) {
 
     const message = document.createElement('span');
     message.className = 'log-message filterable';
-    message.textContent = log.message;
+    renderMessageContent(message, log.message);
     attachContextMenuHandler(message, 'message', log.message || '');
 
     header.appendChild(timestamp);
@@ -799,6 +850,7 @@ function updateConfig(newConfig) {
     const oldCollapseJSON = config.collapseJSON;
     const oldShowRawJSON = config.showRawJSON;
     const oldTheme = config.theme;
+    const oldMessageMaxLength = config.messageMaxLength;
 
     config = { ...config, ...newConfig };
 
@@ -813,8 +865,10 @@ function updateConfig(newConfig) {
         applyTheme(config.theme);
     }
 
-    // Re-render logs if collapseJSON or showRawJSON changed
-    if (oldCollapseJSON !== config.collapseJSON || oldShowRawJSON !== config.showRawJSON) {
+    // Re-render logs if collapseJSON, showRawJSON, or messageMaxLength changed
+    if (oldCollapseJSON !== config.collapseJSON ||
+        oldShowRawJSON !== config.showRawJSON ||
+        oldMessageMaxLength !== config.messageMaxLength) {
         rerenderAllLogs();
     }
 }

--- a/src/webviewPanel.ts
+++ b/src/webviewPanel.ts
@@ -277,7 +277,8 @@ export class SlogViewerWebviewProvider implements vscode.WebviewViewProvider {
       collapseJSON: config.get<boolean>('collapseJSON', true),
       showRawJSON: config.get<boolean>('showRawJSON', false),
       autoScroll: config.get<boolean>('autoScroll', true),
-      theme: config.get<'light' | 'dark' | 'auto'>('theme', 'auto')
+      theme: config.get<'light' | 'dark' | 'auto'>('theme', 'auto'),
+      messageMaxLength: config.get<number>('messageMaxLength', 200)
     };
 
     const message: ExtensionMessage = {


### PR DESCRIPTION
## Summary

Closes #21.

Long messages previously rendered their full text into the DOM, so a single very long (e.g. 1000-line) message loaded entirely into view, hurting readability and performance. The webview now shows a single-line preview capped at a configurable length, with an inline **Show more / Show less** toggle to reveal the full text.

## Changes

- New `slogViewer.messageMaxLength` setting (default `200`, `0` disables truncation)
- `renderMessageContent()` builds the preview + toggle in `createLogElement`
- The toggle stops event propagation so it does not also expand/collapse the JSON body, and pauses auto-scroll on expand (mirrors the header expand behavior)
- Right-click → Copy still copies the **full** message
- CSS: `min-width: 0` flex fix so long unbroken strings can't overflow the row; `pre-wrap` keeps multi-line messages readable when expanded
- The toggle is a real `<button>` for keyboard accessibility

## Testing

- `npm run compile` and `npm test` (66/66) pass
- Manually verified in the Extension Development Host against logs covering: under-limit, exactly-200, 201 chars, a 2000-char unbroken string, a long multi-line message, and a long message on an entry with JSON fields; Copy and the `messageMaxLength` setting re-render confirmed