### PR TITLE
Add configurable field aliases for the log parser (#17)

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,27 @@ Access via VSCode Settings → "Slog Viewer":
 | `slogViewer.showRawJSON` | `false` | Show the raw JSON log below each formatted entry |
 | `slogViewer.autoScroll` | `true` | Automatically scroll to the latest log entry |
 | `slogViewer.theme` | `auto` | Theme for the log viewer (`light`, `dark`, or `auto`) |
+| `slogViewer.messageMaxLength` | `200` | Maximum characters of a message shown before truncation (click "Show more" to expand). Set to `0` to disable. |
+| `slogViewer.timeFieldAliases` | `[]` | Extra field names recognized as the timestamp — see below. |
+| `slogViewer.levelFieldAliases` | `[]` | Extra field names recognized as the log level — see below. |
+| `slogViewer.messageFieldAliases` | `[]` | Extra field names recognized as the message — see below. |
+
+### Field aliases
+
+By default the timestamp, level, and message are read from common field names
+(`time`, `level`, `msg`/`message`, and others). If your logs use different
+keys, add them to the `slogViewer.*FieldAliases` settings and they will be
+rendered into the correct columns. Matching is case-insensitive.
+
+For example, to support Python's `logging` module output:
+
+```json
+"slogViewer.timeFieldAliases": ["asctime"],
+"slogViewer.levelFieldAliases": ["levelname"],
+"slogViewer.messageFieldAliases": ["desc"]
+```
+
+With the settings above, a log like `{"asctime":"2026-04-17 12:10:02","levelname":"INFO","desc":"title 1"}` is displayed the same as a standard `time`/`level`/`message` log. (For logfmt, alias names must be word characters.)
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -165,19 +165,16 @@
     "configuration": {
       "title": "Slog Viewer",
       "properties": {
-        "slogViewer.collapseJSON": {
+        "slogViewer.autoReveal": {
           "type": "boolean",
           "default": true,
-          "description": "Show JSON collapsed by default (click to expand)"
-        },
-        "slogViewer.showRawJSON": {
-          "type": "boolean",
-          "default": false,
-          "description": "Show the raw JSON log below each formatted entry"
+          "order": 1,
+          "description": "Automatically reveal the Slog Viewer panel when the first structured log is detected. When disabled, open the panel manually."
         },
         "slogViewer.autoScroll": {
           "type": "boolean",
           "default": true,
+          "order": 2,
           "description": "Automatically scroll to the latest log entry"
         },
         "slogViewer.theme": {
@@ -188,18 +185,48 @@
             "auto"
           ],
           "default": "auto",
+          "order": 3,
           "description": "Theme for the log viewer (auto uses VSCode theme)"
         },
-        "slogViewer.autoReveal": {
+        "slogViewer.collapseJSON": {
           "type": "boolean",
           "default": true,
-          "description": "Automatically reveal the Slog Viewer panel when the first structured log is detected. When disabled, open the panel manually."
+          "order": 4,
+          "description": "Show JSON collapsed by default (click to expand)"
+        },
+        "slogViewer.showRawJSON": {
+          "type": "boolean",
+          "default": false,
+          "order": 5,
+          "description": "Show the raw JSON log below each formatted entry"
         },
         "slogViewer.messageMaxLength": {
           "type": "number",
           "default": 200,
           "minimum": 0,
+          "order": 6,
           "description": "Maximum characters of a log message shown before truncation. Click \"Show more\" to reveal the full message. Set to 0 to disable truncation."
+        },
+        "slogViewer.timeFieldAliases": {
+          "type": "array",
+          "items": { "type": "string" },
+          "default": [],
+          "order": 7,
+          "markdownDescription": "Extra field names to recognize as the timestamp, in addition to the built-in defaults (`time`, `timestamp`, `ts`, `@timestamp`, `datetime`). Matching is case-insensitive. Example: `asctime`."
+        },
+        "slogViewer.levelFieldAliases": {
+          "type": "array",
+          "items": { "type": "string" },
+          "default": [],
+          "order": 8,
+          "markdownDescription": "Extra field names to recognize as the log level, in addition to the built-in defaults (`level`, `severity`, `lvl`, `loglevel`, `log.level`). Matching is case-insensitive. Example: `levelname`."
+        },
+        "slogViewer.messageFieldAliases": {
+          "type": "array",
+          "items": { "type": "string" },
+          "order": 9,
+          "default": [],
+          "markdownDescription": "Extra field names to recognize as the message, in addition to the built-in defaults (`message`, `msg`, `text`). Matching is case-insensitive. Example: `desc`."
         }
       }
     }

--- a/src/debugAdapterWrapper.ts
+++ b/src/debugAdapterWrapper.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { processLogLine } from './logFormatter';
+import { processLogLine, getFieldAliases } from './logFormatter';
 import { SlogViewerWebviewProvider } from './webviewPanel';
 
 // Maximum number of recent lines to track for deduplication
@@ -36,6 +36,7 @@ export class SlogDebugAdapterTracker implements vscode.DebugAdapterTracker {
 
     // Refresh config to get latest settings
     this.config = vscode.workspace.getConfiguration('slogViewer');
+    const fieldAliases = getFieldAliases(this.config);
 
     // Process lines
     const lines = output.split('\n').filter((line: string) => line.trim());
@@ -59,7 +60,7 @@ export class SlogDebugAdapterTracker implements vscode.DebugAdapterTracker {
       }
 
       // Check if line is a structured log (JSON/logfmt)
-      const parsed = processLogLine(line);
+      const parsed = processLogLine(line, fieldAliases);
       if (parsed) {
         this.webviewProvider.addLog(this.sessionId, parsed);
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -93,6 +93,14 @@ export function activate(context: vscode.ExtensionContext) {
       if (e.affectsConfiguration('slogViewer')) {
         webviewProvider.updateConfig();
       }
+      // Field-alias changes affect parsing — re-parse already-loaded logs
+      if (
+        e.affectsConfiguration('slogViewer.timeFieldAliases') ||
+        e.affectsConfiguration('slogViewer.levelFieldAliases') ||
+        e.affectsConfiguration('slogViewer.messageFieldAliases')
+      ) {
+        webviewProvider.reapplyFieldAliases();
+      }
     })
   );
 }

--- a/src/fileLogLoader.ts
+++ b/src/fileLogLoader.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
 import { StringDecoder } from 'string_decoder';
-import { processLogLine, ParsedLog } from './logFormatter';
+import { processLogLine, getFieldAliases, ParsedLog, FieldAliases } from './logFormatter';
 import { processChunk } from './lineUtils';
 import { SlogViewerWebviewProvider } from './webviewPanel';
 
@@ -19,6 +19,7 @@ interface WatcherState {
   debounceTimer?: ReturnType<typeof setTimeout>;
   isProcessing?: boolean;
   filePath: string;
+  fieldAliases: FieldAliases;
 }
 
 /**
@@ -85,12 +86,15 @@ export class FileLogLoader implements vscode.Disposable {
     this.webviewProvider.addTaskSession(sessionId, sessionName);
     this.webviewProvider.show();
 
+    // Snapshot field aliases for this file's read + watch lifetime
+    const fieldAliases = getFieldAliases(vscode.workspace.getConfiguration('slogViewer'));
+
     // Read and parse the file
     try {
-      const byteOffset = await this.readFile(filePath, sessionId);
+      const byteOffset = await this.readFile(filePath, sessionId, fieldAliases);
 
       if (watch) {
-        this.startWatching(sessionId, normalizedPath, filePath, byteOffset);
+        this.startWatching(sessionId, normalizedPath, filePath, byteOffset, fieldAliases);
       } else {
         this.webviewProvider.endSession(sessionId);
         // Remove from map so file can be reopened
@@ -107,8 +111,8 @@ export class FileLogLoader implements vscode.Disposable {
   /**
    * Parse a line and add to batch, flushing when batch is full.
    */
-  private addToBatch(line: string, batch: ParsedLog[], sessionId: string): boolean {
-    const parsed = processLogLine(line);
+  private addToBatch(line: string, batch: ParsedLog[], sessionId: string, aliases: FieldAliases): boolean {
+    const parsed = processLogLine(line, aliases);
     if (parsed) {
       batch.push(parsed);
       if (batch.length >= LOG_BATCH_SIZE) {
@@ -123,7 +127,7 @@ export class FileLogLoader implements vscode.Disposable {
    * Read a file from start, parsing structured logs.
    * Returns the total bytes read.
    */
-  private readFile(filePath: string, sessionId: string): Promise<number> {
+  private readFile(filePath: string, sessionId: string, aliases: FieldAliases): Promise<number> {
     return new Promise((resolve, reject) => {
       let lineBuffer = '';
       let logCount = 0;
@@ -137,7 +141,7 @@ export class FileLogLoader implements vscode.Disposable {
         totalBytes += Buffer.byteLength(str, 'utf8');
 
         lineBuffer = processChunk(str, lineBuffer, (line) => {
-          if (this.addToBatch(line, batch, sessionId)) {
+          if (this.addToBatch(line, batch, sessionId, aliases)) {
             logCount++;
           }
         });
@@ -146,7 +150,7 @@ export class FileLogLoader implements vscode.Disposable {
       stream.on('end', () => {
         // Flush remaining line buffer
         if (lineBuffer.trim()) {
-          if (this.addToBatch(lineBuffer, batch, sessionId)) {
+          if (this.addToBatch(lineBuffer, batch, sessionId, aliases)) {
             logCount++;
           }
         }
@@ -188,7 +192,7 @@ export class FileLogLoader implements vscode.Disposable {
         const data = decoder.write(buf);
 
         watcherState.lineBuffer = processChunk(data, watcherState.lineBuffer, (line) => {
-          this.addToBatch(line, batch, sessionId);
+          this.addToBatch(line, batch, sessionId, watcherState.fieldAliases);
         });
       });
 
@@ -197,7 +201,7 @@ export class FileLogLoader implements vscode.Disposable {
         const remaining = decoder.end();
         if (remaining) {
           watcherState.lineBuffer = processChunk(remaining, watcherState.lineBuffer, (line) => {
-            this.addToBatch(line, batch, sessionId);
+            this.addToBatch(line, batch, sessionId, watcherState.fieldAliases);
           });
         }
 
@@ -227,12 +231,13 @@ export class FileLogLoader implements vscode.Disposable {
   /**
    * Start watching a file for changes
    */
-  private startWatching(sessionId: string, normalizedPath: string, filePath: string, byteOffset: number): void {
+  private startWatching(sessionId: string, normalizedPath: string, filePath: string, byteOffset: number, fieldAliases: FieldAliases): void {
     const watcherState: WatcherState = {
       watcher: null!,
       byteOffset,
       lineBuffer: '',
-      filePath
+      filePath,
+      fieldAliases
     };
 
     try {
@@ -282,7 +287,7 @@ export class FileLogLoader implements vscode.Disposable {
         this.webviewProvider.clearSessionLogs(sessionId);
         watcherState.byteOffset = 0;
         watcherState.lineBuffer = '';
-        const totalBytes = await this.readFile(watcherState.filePath, sessionId);
+        const totalBytes = await this.readFile(watcherState.filePath, sessionId, watcherState.fieldAliases);
         watcherState.byteOffset = totalBytes;
       } else if (newSize > watcherState.byteOffset) {
         // New data appended — read only new bytes

--- a/src/logFormatter.test.ts
+++ b/src/logFormatter.test.ts
@@ -1,4 +1,4 @@
-import { isJSONLog, parseJSONLog } from './logFormatter';
+import { isJSONLog, parseJSONLog, FieldAliases } from './logFormatter';
 
 describe('logFormatter', () => {
   describe('isJSONLog', () => {
@@ -151,6 +151,74 @@ describe('logFormatter', () => {
       const result = parseJSONLog(input);
       expect(result).not.toBeNull();
       expect(result?.message).toBe('Error: "file not found" at line 42');
+    });
+  });
+
+  describe('field aliases', () => {
+    const pythonAliases: FieldAliases = {
+      time: ['asctime'],
+      level: ['levelname'],
+      message: ['desc'],
+    };
+
+    it('should extract aliased JSON fields into timestamp/level/message', () => {
+      const input = '{"asctime":"2026-04-17 12:10:02","levelname":"INFO","desc":"title 1"}';
+      const result = parseJSONLog(input, pythonAliases);
+      expect(result).not.toBeNull();
+      expect(result?.timestamp).toBe('2026-04-17 12:10:02');
+      expect(result?.level).toBe('INFO');
+      expect(result?.message).toBe('title 1');
+    });
+
+    it('should keep aliased fields out of otherFields', () => {
+      const input = '{"asctime":"2026-04-17 12:10:02","levelname":"INFO","desc":"title 1"}';
+      const result = parseJSONLog(input, pythonAliases);
+      expect(result?.otherFields.asctime).toBeUndefined();
+      expect(result?.otherFields.levelname).toBeUndefined();
+      expect(result?.otherFields.desc).toBeUndefined();
+    });
+
+    it('should leave aliased JSON fields in otherFields when no aliases supplied', () => {
+      const input = '{"asctime":"2026-04-17 12:10:02","levelname":"INFO","desc":"title 1"}';
+      const result = parseJSONLog(input);
+      expect(result?.timestamp).toBeUndefined();
+      expect(result?.level).toBeUndefined();
+      expect(result?.message).toBeUndefined();
+      expect(result?.otherFields.asctime).toBe('2026-04-17 12:10:02');
+      expect(result?.otherFields.desc).toBe('title 1');
+    });
+
+    it('should prefer a built-in field over an alias', () => {
+      const input = '{"time":"t1","asctime":"t2","levelname":"INFO","desc":"hello"}';
+      const result = parseJSONLog(input, pythonAliases);
+      expect(result?.timestamp).toBe('t1');
+    });
+
+    it('should match field names case-insensitively', () => {
+      const input = '{"AscTime":"2026-04-17","LevelName":"warn","Desc":"hi"}';
+      const result = parseJSONLog(input, pythonAliases);
+      expect(result?.timestamp).toBe('2026-04-17');
+      expect(result?.level).toBe('WARN');
+      expect(result?.message).toBe('hi');
+      expect(result?.otherFields.AscTime).toBeUndefined();
+    });
+
+    it('should detect aliased logfmt logs only when aliases are supplied', () => {
+      const line = 'asctime=2026-04-17 levelname=info desc=hello';
+      expect(isJSONLog(line)).toBe(false);
+      expect(isJSONLog(line, pythonAliases)).toBe(true);
+    });
+
+    it('should parse aliased logfmt logs', () => {
+      const result = parseJSONLog('asctime=2026-04-17 levelname=info desc="a message"', pythonAliases);
+      expect(result).not.toBeNull();
+      expect(result?.timestamp).toBe('2026-04-17');
+      expect(result?.level).toBe('INFO');
+      expect(result?.message).toBe('a message');
+    });
+
+    it('should not affect detection of standard logs when aliases are supplied', () => {
+      expect(isJSONLog('time=2024-01-01 level=info msg=hello', pythonAliases)).toBe(true);
     });
   });
 });

--- a/src/logFormatter.ts
+++ b/src/logFormatter.ts
@@ -8,6 +8,66 @@ export interface ParsedLog {
   raw: string;
 }
 
+/** Built-in field names recognized for each canonical field. */
+const TIME_KEYS = ['time', 'timestamp', 'ts', '@timestamp', 'datetime'];
+const LEVEL_KEYS = ['level', 'severity', 'lvl', 'loglevel', 'log.level'];
+const MESSAGE_KEYS = ['message', 'msg', 'text'];
+
+/** User-configured extra field names, in addition to the built-in defaults. */
+export interface FieldAliases {
+  time: string[];
+  level: string[];
+  message: string[];
+}
+
+const EMPTY_ALIASES: FieldAliases = { time: [], level: [], message: [] };
+
+/** Normalize one alias list: strings only, trimmed, non-empty, deduped. */
+function normalizeAliasList(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  const seen = new Set<string>();
+  for (const item of value) {
+    if (typeof item === 'string') {
+      const trimmed = item.trim();
+      if (trimmed) {
+        seen.add(trimmed);
+      }
+    }
+  }
+  return [...seen];
+}
+
+/**
+ * Read the `slogViewer.*FieldAliases` settings into a normalized FieldAliases.
+ */
+export function getFieldAliases(config: vscode.WorkspaceConfiguration): FieldAliases {
+  return {
+    time: normalizeAliasList(config.get('timeFieldAliases')),
+    level: normalizeAliasList(config.get('levelFieldAliases')),
+    message: normalizeAliasList(config.get('messageFieldAliases')),
+  };
+}
+
+/**
+ * Pick the first present field value from a list of candidate key names.
+ * Matching is case-insensitive and based on key existence (not truthiness),
+ * so falsy values like 0 or "" are still selected.
+ */
+function pickField(
+  lowerKeyMap: Map<string, any>,
+  candidates: string[]
+): any {
+  for (const candidate of candidates) {
+    const lower = candidate.toLowerCase();
+    if (lowerKeyMap.has(lower)) {
+      return lowerKeyMap.get(lower);
+    }
+  }
+  return undefined;
+}
+
 /**
  * Strip ANSI color codes from a string
  */
@@ -182,7 +242,7 @@ function parseLogfmt(line: string): Record<string, any> | null {
 /**
  * Check if a line is a structured log (JSON or logfmt)
  */
-export function isJSONLog(line: string): boolean {
+export function isJSONLog(line: string, aliases: FieldAliases = EMPTY_ALIASES): boolean {
   // Strip ANSI codes first
   const cleaned = stripAnsiCodes(line).trim();
 
@@ -196,19 +256,28 @@ export function isJSONLog(line: string): boolean {
     }
   }
 
-  // Check for logfmt format (key=value pairs)
-  // Must have at least time/timestamp and level and msg/message fields
-  const hasTimeField = /\b(?:time|timestamp)=/.test(cleaned);
-  const hasLevelField = /\blevel=/.test(cleaned);
-  const hasMsgField = /\b(?:msg|message)=/.test(cleaned);
+  // Check for logfmt format (key=value pairs). Parse the line and require a
+  // recognized time, level, and message key — this keeps detection aligned
+  // with what parseJSONLog can actually extract.
+  const parsed = parseLogfmt(cleaned);
+  if (!parsed) {
+    return false;
+  }
+  const lowerKeys = new Set(Object.keys(parsed).map(k => k.toLowerCase()));
+  const hasAny = (defaults: string[], extra: string[]): boolean =>
+    [...defaults, ...extra].some(k => lowerKeys.has(k.toLowerCase()));
 
-  return hasTimeField && hasLevelField && hasMsgField;
+  return (
+    hasAny(TIME_KEYS, aliases.time) &&
+    hasAny(LEVEL_KEYS, aliases.level) &&
+    hasAny(MESSAGE_KEYS, aliases.message)
+  );
 }
 
 /**
  * Parse a JSON log line and extract key fields
  */
-export function parseJSONLog(line: string): ParsedLog | null {
+export function parseJSONLog(line: string, aliases: FieldAliases = EMPTY_ALIASES): ParsedLog | null {
   try {
     // Strip ANSI codes before parsing
     const cleaned = stripAnsiCodes(line).trim();
@@ -227,10 +296,22 @@ export function parseJSONLog(line: string): ParsedLog | null {
       obj = parsed;
     }
 
-    // Extract common fields (check various common field names)
-    const timestamp = obj.time || obj.timestamp || obj.ts || obj['@timestamp'] || obj.datetime;
-    let level = obj.level || obj.severity || obj.lvl || obj.loglevel || obj['log.level'];
-    const message = obj.message || obj.msg || obj.text;
+    // Recognized key names: built-in defaults followed by user-configured aliases.
+    const timeKeys = [...TIME_KEYS, ...aliases.time];
+    const levelKeys = [...LEVEL_KEYS, ...aliases.level];
+    const messageKeys = [...MESSAGE_KEYS, ...aliases.message];
+
+    // Lowercased view of the object's keys, used for case-insensitive matching
+    // by both field extraction and the otherFields exclusion.
+    const lowerKeyMap = new Map<string, any>();
+    for (const [key, value] of Object.entries(obj)) {
+      lowerKeyMap.set(key.toLowerCase(), value);
+    }
+
+    // Extract common fields (built-in names + aliases, first match wins)
+    const timestamp = pickField(lowerKeyMap, timeKeys);
+    let level = pickField(lowerKeyMap, levelKeys);
+    const message = pickField(lowerKeyMap, messageKeys);
 
     // Normalize log level to standard values
     if (level) {
@@ -253,25 +334,14 @@ export function parseJSONLog(line: string): ParsedLog | null {
       }
     }
 
-    // Get other fields (excluding the extracted ones)
+    // Get other fields (excluding every recognized timestamp/level/message key).
+    // Uses the same lowercased name set as extraction so the two cannot disagree.
+    const recognizedKeys = new Set(
+      [...timeKeys, ...levelKeys, ...messageKeys].map(k => k.toLowerCase())
+    );
     const otherFields: Record<string, any> = {};
     for (const [key, value] of Object.entries(obj)) {
-      const keyLower = key.toLowerCase();
-      if (
-        keyLower !== 'time' &&
-        keyLower !== 'timestamp' &&
-        keyLower !== 'ts' &&
-        keyLower !== '@timestamp' &&
-        keyLower !== 'datetime' &&
-        keyLower !== 'level' &&
-        keyLower !== 'severity' &&
-        keyLower !== 'lvl' &&
-        keyLower !== 'loglevel' &&
-        keyLower !== 'log.level' &&
-        keyLower !== 'message' &&
-        keyLower !== 'msg' &&
-        keyLower !== 'text'
-      ) {
+      if (!recognizedKeys.has(key.toLowerCase())) {
         otherFields[key] = value;
       }
     }
@@ -336,23 +406,27 @@ export function formatLog(parsed: ParsedLog, config: vscode.WorkspaceConfigurati
  * Returns ParsedLog if the line is a structured log, null otherwise.
  * This is the shared entry point used by all log sources (debug adapter, tasks, file loader).
  */
-export function processLogLine(line: string): ParsedLog | null {
-  if (!isJSONLog(line)) {
+export function processLogLine(line: string, aliases: FieldAliases = EMPTY_ALIASES): ParsedLog | null {
+  if (!isJSONLog(line, aliases)) {
     return null;
   }
-  return parseJSONLog(line);
+  return parseJSONLog(line, aliases);
 }
 
 /**
  * Process a line from the debug console output
  * Returns formatted output if it's a JSON log, otherwise returns null
  */
-export function processLine(line: string, config: vscode.WorkspaceConfiguration): string | null {
-  if (!isJSONLog(line)) {
+export function processLine(
+  line: string,
+  config: vscode.WorkspaceConfiguration,
+  aliases: FieldAliases = EMPTY_ALIASES
+): string | null {
+  if (!isJSONLog(line, aliases)) {
     return null;
   }
 
-  const parsed = parseJSONLog(line);
+  const parsed = parseJSONLog(line, aliases);
   if (!parsed) {
     return null;
   }

--- a/src/messageTypes.ts
+++ b/src/messageTypes.ts
@@ -18,6 +18,7 @@ export interface SessionInfo {
  */
 export type ExtensionMessage =
   | AddLogMessage
+  | ReplaceSessionLogsMessage
   | ClearLogsMessage
   | UpdateConfigMessage
   | SetSessionsMessage
@@ -27,6 +28,16 @@ export interface AddLogMessage {
   type: 'addLog';
   log: ParsedLog;
   sessionId: string;
+}
+
+/**
+ * Replace the entire log list for a session. Used when settings that affect
+ * parsing (e.g. field aliases) change and already-loaded logs must be re-parsed.
+ */
+export interface ReplaceSessionLogsMessage {
+  type: 'replaceSessionLogs';
+  sessionId: string;
+  logs: ParsedLog[];
 }
 
 export interface SetSessionsMessage {

--- a/src/taskOutputTracker.ts
+++ b/src/taskOutputTracker.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import * as cp from 'child_process';
-import { processLogLine } from './logFormatter';
+import { processLogLine, getFieldAliases, FieldAliases } from './logFormatter';
 import { processChunk, normalizeLineEndings } from './lineUtils';
 import { SlogViewerWebviewProvider } from './webviewPanel';
 
@@ -54,6 +54,7 @@ class SlogViewerPseudoterminal implements vscode.Pseudoterminal {
   private processedLines: Set<string> = new Set();
   private processedLinesQueue: string[] = [];
   private hasShownWebview = false;
+  private fieldAliases: FieldAliases = { time: [], level: [], message: [] };
 
   constructor(
     private command: string,
@@ -65,6 +66,9 @@ class SlogViewerPseudoterminal implements vscode.Pseudoterminal {
   ) {}
 
   open(): void {
+    // Snapshot field aliases for this task run
+    this.fieldAliases = getFieldAliases(vscode.workspace.getConfiguration('slogViewer'));
+
     // Build the full command string
     const fullCommand = this.args.length > 0
       ? `${this.command} ${this.args.join(' ')}`
@@ -186,7 +190,7 @@ class SlogViewerPseudoterminal implements vscode.Pseudoterminal {
       }
     }
 
-    const parsed = processLogLine(line);
+    const parsed = processLogLine(line, this.fieldAliases);
     if (parsed) {
       this.webviewProvider.addLog(this.sessionId, parsed);
 

--- a/src/webview/webview.js
+++ b/src/webview/webview.js
@@ -163,6 +163,9 @@ window.addEventListener('message', event => {
         case 'addLog':
             addLogToSession(message.sessionId, message.log);
             break;
+        case 'replaceSessionLogs':
+            replaceSessionLogs(message.sessionId, message.logs);
+            break;
         case 'clearLogs':
             clearCurrentSessionLogs();
             break;
@@ -430,6 +433,36 @@ function addLogToSession(sessionId, log) {
             }
             reindexLogEntries();
         }
+    }
+}
+
+// Replace all logs for a session. Used when a parsing setting (e.g. field
+// aliases) changes and the extension re-parses already-loaded logs.
+function replaceSessionLogs(sessionId, logs) {
+    let session = sessions.get(sessionId);
+    if (!session) {
+        session = {
+            info: { id: sessionId, name: 'Unknown', isActive: true },
+            logs: [],
+            filters: createDefaultFilterState()
+        };
+        sessions.set(sessionId, session);
+    }
+
+    session.logs = logs;
+
+    // Rebuild the set of fields available for filtering from the new logs.
+    const fields = new Set(['message', 'level']);
+    logs.forEach(log => {
+        if (log.otherFields) {
+            Object.keys(log.otherFields).forEach(key => fields.add(key));
+        }
+    });
+    session.filters.availableFields = new Set(fields);
+
+    if (sessionId === currentSessionId) {
+        availableFields = new Set(fields);
+        renderCurrentSessionLogs();
     }
 }
 

--- a/src/webviewPanel.ts
+++ b/src/webviewPanel.ts
@@ -5,7 +5,7 @@
 import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
-import { ParsedLog } from './logFormatter';
+import { ParsedLog, parseJSONLog, getFieldAliases } from './logFormatter';
 import { ExtensionMessage, WebviewConfig, SessionInfo } from './messageTypes';
 
 // Maximum number of logs to buffer before webview is ready
@@ -287,6 +287,41 @@ export class SlogViewerWebviewProvider implements vscode.WebviewViewProvider {
     };
 
     this.view.webview.postMessage(message);
+  }
+
+  /**
+   * Re-parse every stored log with the current field-alias settings and push
+   * the refreshed logs to the webview. Lets a change to the
+   * slogViewer.*FieldAliases settings apply to already-loaded logs without
+   * reopening the source.
+   */
+  public reapplyFieldAliases(): void {
+    const aliases = getFieldAliases(vscode.workspace.getConfiguration('slogViewer'));
+
+    // Re-parse from the original raw line. parseJSONLog is used directly
+    // (rather than processLogLine) because these lines were already detected
+    // as structured logs — only the field extraction needs to be redone.
+    const reparse = (log: ParsedLog): ParsedLog => parseJSONLog(log.raw, aliases) ?? log;
+
+    for (const session of this.sessions.values()) {
+      session.logs = session.logs.map(reparse);
+    }
+    this.pendingLogs = this.pendingLogs.map(({ sessionId, log }) => ({
+      sessionId,
+      log: reparse(log)
+    }));
+
+    if (!this.view || !this.isWebviewReady) {
+      return;
+    }
+    for (const session of this.sessions.values()) {
+      const message: ExtensionMessage = {
+        type: 'replaceSessionLogs',
+        sessionId: session.id,
+        logs: session.logs
+      };
+      this.view.webview.postMessage(message);
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

Closes #17.

The parser only recognized a fixed set of field names for the timestamp, level, and message. Logs from loggers that use other keys — notably Python's `logging` module (`asctime` / `levelname` / `message`) — were not extracted into the correct columns; the values fell into the collapsed JSON body instead.

## Changes

- New settings: `slogViewer.timeFieldAliases`, `slogViewer.levelFieldAliases`, `slogViewer.messageFieldAliases` — string arrays of extra field names to recognize, in addition to the built-in defaults. They render as proper add/remove lists in the Settings UI.
- Resolved aliases are threaded through `processLogLine` for all log sources (debug adapter, tasks, file loader).
- Field matching is now **case-insensitive**, which also fixes a latent bug where a differently-cased key (e.g. `Time`) was dropped from `otherFields` without being extracted.
- logfmt detection now reuses `parseLogfmt` instead of regexes, keeping detection aligned with what the parser can actually extract.
- Changing an alias setting **re-parses already-loaded logs in place** via the new `replaceSessionLogs` message — no need to reopen the source.
- All `slogViewer.*` settings given an explicit `order` so the Settings UI groups them logically.
- README documents the new settings (and the previously-missing `messageMaxLength`).

## Testing

- `npm run compile` and `npm test` (74/74, 8 new) pass; no new lint issues.
- Manually verified in the Extension Development Host: a JSON file using `asctime`/`levelname`/`desc` renders the timestamp/level/message columns once the aliases are configured, and changing the settings updates already-open logs live.